### PR TITLE
Change to repository manager to use 'dist/sql' directory now that G2 build produces that.

### DIFF
--- a/src/test/java/com/senzing/sdk/core/RepositoryManager.java
+++ b/src/test/java/com/senzing/sdk/core/RepositoryManager.java
@@ -503,8 +503,7 @@ public class RepositoryManager {
       File templateDB = null;
       if (INSTALL_LOCATIONS.isDevelopmentBuild()) {
         File    installDir  = INSTALL_LOCATIONS.getInstallDirectory();
-        File    parentDir   = installDir.getParentFile();
-        File    sqlDir      = new File(parentDir, "sql");
+        File    sqlDir      = new File(installDir, "sql");
         File    sqliteFile  = new File(sqlDir, "g2core-schema-sqlite-create.sql");
         File    tmp         = File.createTempFile("G2C-", ".db");
         String  jdbcUrl     = "jdbc:sqlite:" + tmp.getCanonicalPath();


### PR DESCRIPTION
Minor change to RepositoryManager when working with builds using the Senzing engine source tree for obtaining the SQL schema files from the `dist/sql` directory now.  Previously it used `../sql` directory from the source tree, but that does not exist when doing the official builds at the point where the Java SDK is built.

Senzing engine build now creates `dist/sql`.