### PR TITLE
Javadoc fixes and minor test fixes

### DIFF
--- a/src/main/java/com/senzing/sdk/SzEngine.java
+++ b/src/main/java/com/senzing/sdk/SzEngine.java
@@ -429,7 +429,7 @@ public interface SzEngine {
      *                       {@link Set} of non-null {@link Long} entity ID's
      *                       identifying entities to be avoided when finding
      *                       the path, or <code>null</code> if no entities
-     *                       identified by are to be avoided.
+     *                       are to be avoided.
      * 
      * @param requiredDataSources The optional {@link Set} of non-null {@link String}
      *                            data source codes identifying the data sources for
@@ -907,8 +907,8 @@ public interface SzEngine {
      * 
      * @throws SzException If a failure occurs.
      * 
-     * @see SzFlag#SZ_HOW_ENTITY_DEFAULT_FLAGS
-     * @see SzFlagUsageGroup#SZ_HOW_FLAGS
+     * @see SzFlag#SZ_VIRTUAL_ENTITY_DEFAULT_FLAGS
+     * @see SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS
      * 
      * @see #howEntity(long, Set)
      */
@@ -1004,6 +1004,17 @@ public interface SzEngine {
      * when complete.  The first exported line contains the CSV header and
      * each subsequent line contains the exported entity data for a single
      * resolved entity.
+     * <p>
+     * The optionally specified {@link Set} of {@link SzFlag} instances that
+     * not only control how the operation is performed but also the level of
+     * detail provided for the entity and record being analyzed.  The
+     * {@link Set} may contain any {@link SzFlag} value, but only flags
+     * belonging to the {@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} group are
+     * guaranteed to be recognized (other {@link SzFlag} instances will be
+     * ignored unless they have equivalent bit flags).
+     * <p>
+     * <b>NOTE:</b> {@link java.util.EnumSet} offers an efficient means of
+     * constructing a {@link Set} of {@link SzFlag}.
      *
      * @param csvColumnList Specify <code>"*"</code> to indicate "all columns",
      *                      specify empty-string to indicate the "standard
@@ -1083,7 +1094,7 @@ public interface SzEngine {
      * <b>NOTE:</b> {@link java.util.EnumSet} offers an efficient means of
      * constructing a {@link Set} of {@link SzFlag}.
      *
-     * @param redoRecord The redorecord to be processed.
+     * @param redoRecord The redo record to be processed.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
      *              to the {@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} group to control how

--- a/src/test/java/com/senzing/sdk/UtilitiesTest.java
+++ b/src/test/java/com/senzing/sdk/UtilitiesTest.java
@@ -4,21 +4,33 @@ import javax.json.JsonObject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.senzing.util.JsonUtilities;
+import com.senzing.sdk.core.AbstractTest;
 
 import static org.junit.jupiter.api.TestInstance.Lifecycle;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @Execution(ExecutionMode.SAME_THREAD)
-public class UtilitiesTest {
+public class UtilitiesTest extends AbstractTest {
+    @BeforeAll
+    public void initialize() {
+        this.beginTests();
+    }
+
+    @AfterAll
+    public void complete() {
+        this.endTests();
+    }
+
     @ParameterizedTest
     @ValueSource(longs = {0L, 1L, 2L, 20L, 40L, 80L, 160L, 3200L, 64000L, 128345789L})
     public void testHexFormat(long value) {

--- a/src/test/java/com/senzing/sdk/core/AbstractTest.java
+++ b/src/test/java/com/senzing/sdk/core/AbstractTest.java
@@ -91,7 +91,7 @@ public abstract class AbstractTest {
      * Signals the end of the current test suite.
      */
     protected void endTests() {
-        // do nothing for now
+        this.conditionallyLogCounts(true);
     }
 
     /**
@@ -460,8 +460,8 @@ public abstract class AbstractTest {
 
     /**
      * This method can typically be called from a method annotated with
-     * "@BeforeAll". It will create a Senzing entity repository and
-     * initialize and start the Senzing API Server.
+     * <code>"@BeforeAll"</code>. It will create and initialize the
+     * Senzing entity repository.
      */
     protected void initializeTestEnvironment() {
         this.initializeTestEnvironment(false);
@@ -469,8 +469,8 @@ public abstract class AbstractTest {
 
     /**
      * This method can typically be called from a method annotated with
-     * "@BeforeAll". It will create a Senzing entity repository and
-     * initialize and start the Senzing API Server.
+     * <code>"@BeforeAll"</code>. It will create a Senzing entity
+     * repository and initialize and start the Senzing API Server.
      * 
      * @param excludeConfig <code>true</code> if the default configuration
      *                      should be excluded from the repository, and

--- a/src/test/java/com/senzing/sdk/core/SzCoreDiagnosticTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreDiagnosticTest.java
@@ -24,6 +24,7 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonArray;
 
+import com.senzing.sdk.SzException;
 import com.senzing.sdk.SzDiagnostic;
 
 import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -216,6 +217,25 @@ import static org.junit.jupiter.params.provider.Arguments.*;
                 
             } catch (Exception e) {
                 fail("Failed testPurgeRepository test with exception", e);
+            }
+        });
+    }
+
+    @Test
+    @Order(40)
+    public void testGetBadFeature()
+    {
+        this.performTest(() -> {
+            try {
+                SzDiagnostic diagnostic = this.env.getDiagnostic();
+
+                diagnostic.getFeature(100000000L);
+
+                fail("GetFeature() unexpected succeeded with bad "
+                     + "feature ID");
+
+            } catch (SzException e) {
+                /// expected
             }
         });
     }

--- a/src/test/java/com/senzing/sdk/core/SzCoreEngineReadTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreEngineReadTest.java
@@ -210,12 +210,12 @@ public class SzCoreEngineReadTest extends AbstractTest {
         EXPORT_FLAG_SETS = Collections.unmodifiableList(list);
     }
 
-    private static final Map<SzRecordKey, Long> LOADED_RECORD_MAP
-        = Collections.synchronizedMap(new LinkedHashMap<>());
-
-    private static final Map<Long, Set<SzRecordKey>> LOADED_ENTITY_MAP
-        = Collections.synchronizedMap(new LinkedHashMap<>());
+    private Map<SzRecordKey, Long> loadedRecordMap
+        = new LinkedHashMap<>();
     
+    private Map<Long, Set<SzRecordKey>> loadedEntityMap
+        = new LinkedHashMap<>();
+
     private static final List<SzRecordKey> RECORD_KEYS
         = List.of(ABC123,
                   DEF456,
@@ -264,11 +264,11 @@ public class SzCoreEngineReadTest extends AbstractTest {
                 JsonObject  jsonObj     = parseJsonObject(sb.toString());
                 JsonObject  entity      = getJsonObject(jsonObj, "RESOLVED_ENTITY");
                 Long        entityId    = getLong(entity, "ENTITY_ID");
-                LOADED_RECORD_MAP.put(key, entityId);
-                Set<SzRecordKey> recordKeySet = LOADED_ENTITY_MAP.get(entityId);
+                this.loadedRecordMap.put(key, entityId);
+                Set<SzRecordKey> recordKeySet = this.loadedEntityMap.get(entityId);
                 if (recordKeySet == null) {
                     recordKeySet = new LinkedHashSet<>();
-                    LOADED_ENTITY_MAP.put(entityId, recordKeySet);
+                    this.loadedEntityMap.put(entityId, recordKeySet);
                 }
                 recordKeySet.add(key);
             };
@@ -284,8 +284,8 @@ public class SzCoreEngineReadTest extends AbstractTest {
                                       .build();
     }
 
-    public static Long getEntityId(SzRecordKey recordKey) {
-        return LOADED_RECORD_MAP.get(recordKey);
+    public Long getEntityId(SzRecordKey recordKey) {
+        return this.loadedRecordMap.get(recordKey);
     }
 
     /**
@@ -564,7 +564,7 @@ public class SzCoreEngineReadTest extends AbstractTest {
 
                 } catch (Exception e) {
                     // TODO(bcaceres): This should have succeeded but currently fails
-                    //fail("Failed to close an export handle more than once.", e);
+                    // fail("Failed to close an export handle more than once.", e);
                 }
 
                 String fullExport = sw.toString();
@@ -586,8 +586,8 @@ public class SzCoreEngineReadTest extends AbstractTest {
                     
                     if (columnList.equals("*") || columnList.length() == 0) {
                         assertTrue(headers.contains("RESOLVED_ENTITY_ID"),
-                            "Default columns exported, but ENTITY_ID not found in headers ("
-                            + headers + "): " + testData);
+                            "Default columns exported, but RESOLVED_ENTITY_ID not found "
+                            + "in headers (" + headers + "): " + testData);
                     
                     } else {
                         String[] columns = columnList.split(",");
@@ -899,7 +899,6 @@ public class SzCoreEngineReadTest extends AbstractTest {
                 "Get record for " + recordKey + " test",
                 recordKey,
                 flagSetIter.next(), 
-                null,
                 null));
         }
 

--- a/src/test/java/com/senzing/sdk/core/SzCoreEngineWriteTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreEngineWriteTest.java
@@ -287,12 +287,6 @@ public class SzCoreEngineWriteTest extends AbstractTest {
         RECORD_FLAG_SETS = Collections.unmodifiableList(list);
     }
 
-    private static final Map<SzRecordKey, Long> LOADED_RECORD_MAP
-        = Collections.synchronizedMap(new LinkedHashMap<>());
-
-    private static final Map<Long, Set<SzRecordKey>> LOADED_ENTITY_MAP
-        = Collections.synchronizedMap(new LinkedHashMap<>());
-
     private static final SzRecordKey PASSENGER_ABC123
         = SzRecordKey.of(PASSENGERS_DATA_SOURCE, "ABC123");
     
@@ -344,6 +338,12 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                   VIP_GHI123,
                   VIP_JKL456);
 
+    private Map<SzRecordKey, Long> loadedRecordMap
+        = new LinkedHashMap<>();
+    
+    private Map<Long, Set<SzRecordKey>> loadedEntityMap
+        = new LinkedHashMap<>();
+    
     private SzCoreEnvironment env = null;
 
     @BeforeAll
@@ -376,11 +376,11 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                 JsonObject  jsonObj     = parseJsonObject(sb.toString());
                 JsonObject  entity      = getJsonObject(jsonObj, "RESOLVED_ENTITY");
                 Long        entityId    = getLong(entity, "ENTITY_ID");
-                LOADED_RECORD_MAP.put(key, entityId);
-                Set<SzRecordKey> recordKeySet = LOADED_ENTITY_MAP.get(entityId);
+                this.loadedRecordMap.put(key, entityId);
+                Set<SzRecordKey> recordKeySet = this.loadedEntityMap.get(entityId);
                 if (recordKeySet == null) {
                     recordKeySet = new LinkedHashSet<>();
-                    LOADED_ENTITY_MAP.put(entityId, recordKeySet);
+                    this.loadedEntityMap.put(entityId, recordKeySet);
                 }
                 recordKeySet.add(key);
             };
@@ -762,7 +762,7 @@ public class SzCoreEngineWriteTest extends AbstractTest {
 
         Iterator<Set<SzFlag>> flagSetIter = circularIterator(WRITE_FLAG_SETS);
 
-        for (SzRecordKey key : LOADED_RECORD_MAP.keySet()) {
+        for (SzRecordKey key : this.loadedRecordMap.keySet()) {
             Class<?>    exceptionType   = null;
             Set<SzFlag> flagSet         = flagSetIter.next();
             
@@ -872,7 +872,7 @@ public class SzCoreEngineWriteTest extends AbstractTest {
 
         Iterator<Set<SzFlag>> flagSetIter = circularIterator(WRITE_FLAG_SETS);
 
-        for (Long entityId : LOADED_RECORD_MAP.values()) {
+        for (Long entityId : this.loadedRecordMap.values()) {
             Class<?>    exceptionType   = null;
             Set<SzFlag> flagSet         = flagSetIter.next();
             
@@ -912,7 +912,7 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                               Class<?>      expectedExceptionType) 
     {
         String testData = "entityId=[ " + entityId + " ], havingRecords=[ "
-            + LOADED_ENTITY_MAP.get(entityId) + " ], withFlags=[ " 
+            + this.loadedEntityMap.get(entityId) + " ], withFlags=[ " 
             + SzFlag.toString(flags) + " ], expectedException=[ "
             + expectedExceptionType + " ]";
 
@@ -978,7 +978,7 @@ public class SzCoreEngineWriteTest extends AbstractTest {
 
         Iterator<Set<SzFlag>> flagSetIter = circularIterator(WRITE_FLAG_SETS);
 
-        for (SzRecordKey key : LOADED_RECORD_MAP.keySet()) {
+        for (SzRecordKey key : this.loadedRecordMap.keySet()) {
             Class<?>    exceptionType   = null;
             Set<SzFlag> flagSet         = flagSetIter.next();
             

--- a/src/test/java/com/senzing/sdk/core/SzCoreEnvironmentTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreEnvironmentTest.java
@@ -93,7 +93,6 @@ public class SzCoreEnvironmentTest extends AbstractTest {
     @AfterAll public void teardownEnvironment() {
         try {
             this.teardownTestEnvironment();
-            this.conditionallyLogCounts(true);
         } finally {
             this.endTests();
         }

--- a/src/test/java/com/senzing/sdk/core/SzExceptionTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzExceptionTest.java
@@ -1,5 +1,7 @@
 package com.senzing.sdk.core;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -27,7 +29,7 @@ import static com.senzing.sdk.core.AbstractTest.*;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @Execution(ExecutionMode.SAME_THREAD)
-public class SzExceptionTest {
+public class SzExceptionTest extends AbstractTest {
     public List<Class<? extends SzException>> getExceptionTypes() {
         return List.of(
             SzException.class,
@@ -47,6 +49,16 @@ public class SzExceptionTest {
             result.add(Arguments.of(args.toArray()));
         }
         return result;
+    }
+
+    @BeforeAll
+    public void initialize() {
+        this.beginTests();
+    }
+
+    @AfterAll
+    public void complete() {
+        this.endTests();
     }
 
     @ParameterizedTest

--- a/src/test/java/com/senzing/sdk/core/SzFlagTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzFlagTest.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashSet;
 import java.util.Arrays;
 import java.util.LinkedList;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -35,7 +36,7 @@ import static com.senzing.sdk.core.Utilities.*;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @Execution(ExecutionMode.SAME_THREAD)
-public class SzFlagTest {
+public class SzFlagTest extends AbstractTest {
     /**
      * The {@link Map} of {@link String} constant names from
      * {@link SzFlags} to their values.
@@ -57,6 +58,7 @@ public class SzFlagTest {
 
     @BeforeAll
     public void reflectFlags() {
+        this.beginTests();
         // initialize the enum classes
         SzFlag.values();
         SzFlagUsageGroup.values();
@@ -101,6 +103,11 @@ public class SzFlagTest {
                 fail("Got exception in reflection.", e);
             }
         }
+    }
+
+    @AfterAll
+    public void complete() {
+        this.endTests();
     }
 
     private List<Arguments> getFlagsMappings() {

--- a/src/test/java/com/senzing/sdk/core/UtilitiesTest.java
+++ b/src/test/java/com/senzing/sdk/core/UtilitiesTest.java
@@ -4,8 +4,12 @@ import javax.json.JsonObject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -14,7 +18,18 @@ import com.senzing.util.JsonUtilities;
 import static org.junit.jupiter.api.TestInstance.Lifecycle;
 
 @TestInstance(Lifecycle.PER_CLASS)
-public class UtilitiesTest {
+@Execution(ExecutionMode.SAME_THREAD)
+public class UtilitiesTest extends AbstractTest {
+    @BeforeAll
+    public void initialize() {
+        this.beginTests();
+    }
+
+    @AfterAll
+    public void complete() {
+        this.endTests();
+    }
+
     @ParameterizedTest
     @ValueSource(longs = {0L, 1L, 2L, 20L, 40L, 80L, 160L, 3200L, 64000L, 128345789L})
     public void testHexFormat(long value) {


### PR DESCRIPTION
Minor test fixes making some variables member variables instead of static and removing unnecessary code.

Many Javadoc fixes discovered during C# development.
