### PR TITLE
Made changes to return null when INFO is not requested.

### DIFF
--- a/src/main/java/com/senzing/sdk/SzDatabaseException.java
+++ b/src/main/java/com/senzing/sdk/SzDatabaseException.java
@@ -2,7 +2,7 @@ package com.senzing.sdk;
 
 /**
  * Extends {@link SzUnrecoverableException} to define an exceptional
- * condition triggered by a database error from which we can recover
+ * condition triggered by a database error from which we cannot recover
  * (e.g.: missing or unexpected schema definition).
  */
 public class SzDatabaseException extends SzUnrecoverableException {

--- a/src/main/java/com/senzing/sdk/SzEngine.java
+++ b/src/main/java/com/senzing/sdk/SzEngine.java
@@ -54,8 +54,9 @@ public interface SzEngine {
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
      *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
      * 
-     * @return The JSON {@link String} result produced by adding the
-     *         record to the repository (depending on the specified flags).
+     * @return The JSON {@link String} result produced by adding the record to the
+     *         repository, or <code>null</code> if the specified flags do not 
+     *         indicate that an INFO message should be returned.
      * 
      * @throws SzUnknownDataSourceException If an unrecognized data source
      *                                      code is specified.
@@ -129,8 +130,9 @@ public interface SzEngine {
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
      *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
      *
-     * @return The JSON {@link String} result produced by deleting the
-     *         record from the repository (depending on the specified flags).
+     * @return The JSON {@link String} result produced by deleting the record from
+     *         the repository, or <code>null</code> if the specified flags do not 
+     *         indicate that an INFO message should be returned.
      * 
      * @throws SzUnknownDataSourceException If an unrecognized data source
      *                                      code is specified.
@@ -170,8 +172,9 @@ public interface SzEngine {
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
      *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
      *
-     * @return The JSON {@link String} result produced by reevaluating the
-     *         record in the repository (depending on the specified flags).
+     * @return The JSON {@link String} result produced by reevaluating the record
+     *         in the repository, or <code>null</code> if the specified flags do
+     *         not indicate that an INFO message should be returned.
      *
      * @throws SzUnknownDataSourceException If an unrecognized data source
      *                                      code is specified.
@@ -207,8 +210,9 @@ public interface SzEngine {
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
      *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
      *
-     * @return The JSON {@link String} result produced by reevaluating the
-     *         entity in the repository (depending on the specified flags).
+     * @return The JSON {@link String} result produced by reevaluating the entity
+     *         in the repository, or <code>null</code> if the specified flags do
+     *         not indicate that an INFO message should be returned.
      * 
      * @throws SzException If a failure occurs.
      * 
@@ -1168,8 +1172,9 @@ public interface SzEngine {
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
      *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
      * 
-     * @return The JSON {@link String} result produced by adding the
-     *         record to the repository (depending on the specified flags).
+     * @return The JSON {@link String} result produced by processing the redo record
+     *         in the repository, or <code>null</code> if the specified flags do not 
+     *         indicate that an INFO message should be returned.
      * 
      * @throws SzException If a failure occurs.
      * 

--- a/src/main/java/com/senzing/sdk/core/SzCoreEngine.java
+++ b/src/main/java/com/senzing/sdk/core/SzCoreEngine.java
@@ -30,7 +30,8 @@ class SzCoreEngine implements SzEngine {
      * The empty response for operations where the info can optionally
      * generated but was not requested.
      */
-    static final String NO_INFO = "{}";
+    static final String NO_INFO = """
+            {"AFFECTED_ENTITIES":[],"INTERESTING_ENTITIES":{"ENTITIES":[]}}""";
 
     /**
      * The {@link SzCoreEnvironment} that constructed this instance.
@@ -147,7 +148,7 @@ class SzCoreEngine implements SzEngine {
             long downstreamFlags = SzFlag.toLong(flags) & SDK_FLAG_MASK;
 
             int returnCode = 0;
-            String result = NO_INFO;
+            String result = null;
             // check if we have flags to pass downstream or need info
             if (downstreamFlags == 0L
                 && (flags == null || !flags.contains(SZ_WITH_INFO)))
@@ -259,7 +260,7 @@ class SzCoreEngine implements SzEngine {
             long downstreamFlags = SzFlag.toLong(flags) & SDK_FLAG_MASK;
 
             int returnCode = 0;
-            String result = NO_INFO;
+            String result = null;
             // check if we have flags to pass downstream or need info
             if (downstreamFlags == 0L 
                 && (flags == null || !flags.contains(SZ_WITH_INFO))) 
@@ -954,7 +955,7 @@ class SzCoreEngine implements SzEngine {
     {
         return this.env.execute(() -> {
             int returnCode = 0;
-            String result = NO_INFO;
+            String result = null;
             // check if we have flags to pass downstream
             if (flags == null || !flags.contains(SZ_WITH_INFO)) {
                 returnCode = this.nativeApi.processRedoRecord(redoRecord);
@@ -988,7 +989,7 @@ class SzCoreEngine implements SzEngine {
             long downstreamFlags = SzFlag.toLong(flags) & SDK_FLAG_MASK;
 
             int returnCode = 0;
-            String result = NO_INFO;
+            String result = null;
 
             // check if we have flags to pass downstream or need info
             if (flags == null || !flags.contains(SZ_WITH_INFO)) {
@@ -1033,7 +1034,7 @@ class SzCoreEngine implements SzEngine {
             long downstreamFlags = SzFlag.toLong(flags) & SDK_FLAG_MASK;
 
             int returnCode = 0;
-            String result = NO_INFO;
+            String result = null;
 
             // check if we have flags to pass downstream or need info
             if (flags == null || !flags.contains(SZ_WITH_INFO)) {
@@ -1054,12 +1055,6 @@ class SzCoreEngine implements SzEngine {
                     
                 // set the info result
                 result = sb.toString();
-
-                // TODO(bcaceres): remove this if not-found records produce an error
-                // check if record not found yields empty INFO
-                if (result.length() == 0) {
-                    result = NO_INFO;
-                }
             }
 
             // check the return code

--- a/src/test/java/com/senzing/sdk/core/SzCoreEngineWriteTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreEngineWriteTest.java
@@ -13,11 +13,9 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.parallel.Execution;
@@ -702,9 +700,9 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                                 "Info message lacking AFFECTED_ENTITIES key: "
                                 + testData);
                 } else {
-                    assertEquals(SzCoreEngine.NO_INFO, result,
-                                "No INFO requested, but non-empty response received: "
-                                + testData);
+                    assertNull(result,
+                               "No INFO requested, but non-empty response received: "
+                               + testData);
                 }
 
             } catch (Exception e) {
@@ -837,8 +835,8 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                                     "Info message lacking AFFECTED_ENTITIES key: " + testData);
                     }
                 } else {
-                    assertEquals(SzCoreEngine.NO_INFO, result,
-                                "No INFO requested, but non-empty response received");
+                    assertNull(result,
+                       "No INFO requested, but non-empty response received");
                 }
 
             } catch (Exception e) {
@@ -932,17 +930,13 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                     JsonObject jsonObject = parseJsonObject(result);
 
                     if (jsonObject.size() > 0) {
-                        assertTrue(jsonObject.containsKey("DATA_SOURCE"),
-                                "Info message lacking DATA_SOURCE key: " + testData);
-                        assertTrue(jsonObject.containsKey("RECORD_ID"),
-                                    "Info message lacking RECORD_ID key: " + testData);
                         assertTrue(jsonObject.containsKey("AFFECTED_ENTITIES"),
                                     "Info message lacking AFFECTED_ENTITIES key: " + testData);
                     }
                 } else {
-                    assertEquals(SzCoreEngine.NO_INFO, result,
-                                 "No INFO requested, but non-empty response received: "
-                                 + testData);
+                    assertNull(result,
+                               "No INFO requested, but non-empty response received: "
+                               + testData);
                 }
 
             } catch (Exception e) {
@@ -1043,9 +1037,9 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                                 "Info message lacking AFFECTED_ENTITIES key: "
                                 + testData);
                 } else {
-                    assertEquals(SzCoreEngine.NO_INFO, result,
-                                "No INFO requested, but non-empty response received: "
-                                + testData);
+                    assertNull(result,
+                               "No INFO requested, but non-empty response received: "
+                               + testData);
                 }
 
             } catch (Exception e) {
@@ -1172,9 +1166,9 @@ public class SzCoreEngineWriteTest extends AbstractTest {
                                    "Info message lacking AFFECTED_ENTITIES key for redo: "
                                    + redoRecord);
                     } else {
-                        assertEquals(SzCoreEngine.NO_INFO, result,
-                                     "No INFO requested, but non-empty response "
-                                     + "received for redo: " + redoRecord);
+                        assertNull(result,
+                                   "No INFO requested, but non-empty response "
+                                   + "received for redo: " + redoRecord);
                     }
                 }
 


### PR DESCRIPTION
Made changes to return null when INFO is not requested.

ALSO: Patched reevaluateEntity() return place-holder NoInfo when INFO requested, but entity ID not found

Resolves Issue #80 

