### PR TITLE
Updates for version 4.0.0-beta.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0-beta.1.1] - 2025-02-04
+
+### Changed in 4.0.0-beta.1.1
+
+- Changed versioning to match major version of Senzing 4.0 product with beta suffix.
+- Made changes to return `null` when INFO is **not** requested.
+- Patched `SzCoreEngine.reevaluateEntity()` to return place-holder `NoInfo` when
+  INFO requested, but entity not found (pending fix to native engine function).
+- Added new engine flags:
+    - `SZ_SEARCH_INCLUDE_ALL_CANDIDATES`
+    - `SZ_SEARCH_INCLUDE_REQUEST`
+    - `SZ_SEARCH_INCLUDE_REQUEST_DETAILS`
+
 ## [0.9.1] - 2025-01-17
 
 ### Changed in 0.9.1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.0</version>
+  <version>4.0.0-beta.1.1</version>
   <name>Senzing Java SDK</name>
   <description>The Java SDK for Senzing.  This calls through to the native Senzing SDK via JNI.</description>
   <url>http://github.com/senzing-garage/sz-sdk-java</url>

--- a/src/main/java/com/senzing/sdk/SzFlag.java
+++ b/src/main/java/com/senzing/sdk/SzFlag.java
@@ -673,7 +673,53 @@ public enum SzFlag {
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
     SZ_SEARCH_INCLUDE_NAME_ONLY(
-        SzFlags.SZ_SEARCH_INCLUDE_NAME_ONLY, SZ_SEARCH_SET);
+        SzFlags.SZ_SEARCH_INCLUDE_NAME_ONLY, SZ_SEARCH_SET),
+
+    /**
+     * The value for search functionality to indicate that
+     * search results should not only include those entities that
+     * satisfy resolution rule, but also those that present on the
+     * candidate list but fail to satisfy a resolution rule.
+     * <p>
+     * This flag belongs to the following usage groups:
+     * <ul>
+     *    <li>{@link SzFlagUsageGroup#SZ_SEARCH_FLAGS} 
+     * </ul>
+     * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
+     */
+    SZ_SEARCH_INCLUDE_ALL_CANDIDATES(
+        SzFlags.SZ_SEARCH_INCLUDE_ALL_CANDIDATES, SZ_SEARCH_SET),
+    
+    /**
+     * The value for search functionality to indicate that 
+     * the search response should include the basic feature
+     * information for the search criteria features.
+     * <p>
+     * This flag belongs to the following usage groups:
+     * <ul>
+     *    <li>{@link SzFlagUsageGroup#SZ_SEARCH_FLAGS} 
+     * </ul>
+     * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
+     */
+    SZ_SEARCH_INCLUDE_REQUEST(
+        SzFlags.SZ_SEARCH_INCLUDE_REQUEST, SZ_SEARCH_SET),
+
+    /**
+     * The value for search functionality to indicate that 
+     * the search response should include detailed feature 
+     * information for search criteria features (including feature
+     * stats and generic status).  This flag has no effect unless
+     * {@link #SZ_SEARCH_INCLUDE_REQUEST} is also specified.
+     * <p>
+     * This flag belongs to the following usage groups:
+     * <ul>
+     *    <li>{@link SzFlagUsageGroup#SZ_SEARCH_FLAGS} 
+     * </ul>
+     * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
+     * 
+     */
+    SZ_SEARCH_INCLUDE_REQUEST_DETAILS(
+        SzFlags.SZ_SEARCH_INCLUDE_REQUEST_DETAILS, SZ_SEARCH_SET);
 
     /**
      * An <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances 
@@ -797,6 +843,9 @@ public enum SzFlag {
         flagSet.add(SZ_SEARCH_INCLUDE_POSSIBLY_SAME);
         flagSet.add(SZ_SEARCH_INCLUDE_POSSIBLY_RELATED);
         flagSet.add(SZ_SEARCH_INCLUDE_NAME_ONLY);
+        flagSet.add(SZ_SEARCH_INCLUDE_ALL_CANDIDATES);
+        flagSet.add(SZ_SEARCH_INCLUDE_REQUEST);
+        flagSet.add(SZ_SEARCH_INCLUDE_REQUEST_DETAILS);
         SZ_SEARCH_ALL_FLAGS = Collections.unmodifiableSet(flagSet);
     }
 

--- a/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
+++ b/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
@@ -241,6 +241,9 @@ public enum SzFlagUsageGroup {
      *      <li>{@link SzFlag#SZ_SEARCH_INCLUDE_POSSIBLY_SAME}
      *      <li>{@link SzFlag#SZ_SEARCH_INCLUDE_POSSIBLY_RELATED}
      *      <li>{@link SzFlag#SZ_SEARCH_INCLUDE_NAME_ONLY}
+     *      <li>{@link SzFlag#SZ_SEARCH_INCLUDE_ALL_CANDIDATES}
+     *      <li>{@link SzFlag#SZ_SEARCH_INCLUDE_REQUEST}
+     *      <li>{@link SzFlag#SZ_SEARCH_INCLUDE_REQUEST_DETAILS}
      * </ul>
      * <p>
      * The pre-defined {@link SzFlag} {@link Set} instances that use this

--- a/src/main/java/com/senzing/sdk/SzFlags.java
+++ b/src/main/java/com/senzing/sdk/SzFlags.java
@@ -302,7 +302,6 @@ public final class SzFlags {
     /**
      * The bitwise flag for search functionality to indicate that
      * we should include "possibly related" match level results.
-     *
      */
     public static final long SZ_SEARCH_INCLUDE_POSSIBLY_RELATED 
         = (SZ_EXPORT_INCLUDE_POSSIBLY_RELATED);
@@ -310,10 +309,36 @@ public final class SzFlags {
     /**
      * The bitwise flag for search functionality to indicate that
      * we should include "name only" match level results.
-     *
      */
     public static final long SZ_SEARCH_INCLUDE_NAME_ONLY
         = (SZ_EXPORT_INCLUDE_NAME_ONLY);
+
+    /**
+     * The bitwise flag for search functionality to indicate that
+     * search results should not only include those entities that
+     * satisfy resolution rule, but also those that present on the
+     * candidate list but fail to satisfy a resolution rule.
+     */
+    public static final long SZ_SEARCH_INCLUDE_ALL_CANDIDATES
+        = (1L << 32);
+
+    /**
+     * The bitwise flag for search functionality to indicate that
+     * the search response should include the basic feature
+     * information for the search criteria features.
+     */
+    public static final long SZ_SEARCH_INCLUDE_REQUEST
+        = (1L << 37);
+
+    /**
+     * The bitwise flag for search functionality to indicate that
+     * the search response should include detailed feature 
+     * information for search criteria features (including feature
+     * stats and generic status).  This flag has no effect unless
+     * {@link #SZ_SEARCH_INCLUDE_REQUEST} is also specified.
+     */
+    public static final long SZ_SEARCH_INCLUDE_REQUEST_DETAILS
+        = (1L << 38);
 
     /**
      * The bitwise flag to use when a repository-modifying operation 

--- a/src/main/java/com/senzing/sdk/core/NativeEngine.java
+++ b/src/main/java/com/senzing/sdk/core/NativeEngine.java
@@ -253,6 +253,34 @@ interface NativeEngine extends NativeApi {
 
     /**
      * The bitwise flag for search functionality to indicate that
+     * search results should not only include those entities that
+     * satisfy resolution rule, but also those that present on the
+     * candidate list but fail to satisfy a resolution rule.
+     */
+    long SZ_SEARCH_INCLUDE_ALL_CANDIDATES
+        = (1L << 32);
+
+    /**
+     * The bitwise flag for search functionality to indicate that
+     * the search response should include the basic feature
+     * information for the search criteria features.
+     */
+    long SZ_SEARCH_INCLUDE_REQUEST
+        = (1L << 37);
+
+    /**
+     * The bitwise flag for search functionality to indicate that
+     * the search response should include detailed feature 
+     * information for search criteria features (including feature
+     * stats and generic status).  This flag has no effect unless
+     * {@link #SZ_SEARCH_INCLUDE_REQUEST} is also specified.
+     */
+    long SZ_SEARCH_INCLUDE_REQUEST_DETAILS
+        = (1L << 38);
+
+
+    /**
+     * The bitwise flag for search functionality to indicate that
      * we should include all match level results.
      *
      */

--- a/src/test/java/com/senzing/sdk/core/SzCoreConfigTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreConfigTest.java
@@ -4,16 +4,13 @@ import javax.json.JsonObject;
 import javax.json.JsonArray;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import com.senzing.sdk.SzConfig;
-import com.senzing.sdk.SzConfigManager;
 import com.senzing.sdk.SzException;
 
 import static org.junit.jupiter.api.TestInstance.Lifecycle;

--- a/src/test/java/com/senzing/sdk/core/SzFlagTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzFlagTest.java
@@ -13,7 +13,6 @@ import java.util.LinkedList;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;


### PR DESCRIPTION
- Changed versioning to match major version of Senzing 4.0 product with beta suffix.
- Made changes to return `null` when INFO is **not** requested.
- Patched `SzCoreEngine.reevaluateEntity()` to return place-holder `NoInfo` when
  INFO requested, but entity not found (pending fix to native engine function).
- Added new engine flags:
    - `SZ_SEARCH_INCLUDE_ALL_CANDIDATES`
    - `SZ_SEARCH_INCLUDE_REQUEST`
    - `SZ_SEARCH_INCLUDE_REQUEST_DETAILS`

Resolves Issue #84 
