### PR TITLE
Removed reliance on hard-coded NO_INFO return value from reevaluateEntity(SZ_WITH_INFO_FLAGS)

### DIFF
--- a/src/main/java/com/senzing/sdk/core/SzCoreEngine.java
+++ b/src/main/java/com/senzing/sdk/core/SzCoreEngine.java
@@ -27,13 +27,6 @@ class SzCoreEngine implements SzEngine {
     private static final long SDK_FLAG_MASK = ~(SzFlags.SZ_WITH_INFO);
 
     /**
-     * The empty response for operations where the info can optionally
-     * generated but was not requested.
-     */
-    static final String NO_INFO = """
-            {"AFFECTED_ENTITIES":[],"INTERESTING_ENTITIES":{"ENTITIES":[]}}""";
-
-    /**
      * The {@link SzCoreEnvironment} that constructed this instance.
      */
     private SzCoreEnvironment env = null;
@@ -1005,11 +998,6 @@ class SzCoreEngine implements SzEngine {
                     
                 // set the info result if requested
                 result = sb.toString();
-
-                // check if record not found yields empty INFO
-                if (result.length() == 0) {
-                    result = NO_INFO;
-                }
             }
 
             // check the return code


### PR DESCRIPTION
Now that GDEV-3969 has been resolved to modify `Sz_reevaluateEntityWithInfo()` to return info indicating no affected entities when an entity is not found, we no longer need to have a hard-coded return value for the INFO to allow the unit tests to pass.

`SzCoreEngine.java` has been modified to remove the check for an empty-string INFO and hard-coded replacement with the `NO_INFO` constant.

Resolves Issue #89 