### PR TITLE
Fixed mistake in error message in InstallLocations.java (forgot to save this file)

### DIFF
--- a/.github/workflows/maven-darwin.yaml
+++ b/.github/workflows/maven-darwin.yaml
@@ -36,7 +36,6 @@ jobs:
         run: |
           SENZING_PATH="${HOME}/senzing"
           {
-            echo "SENZING_PATH=${SENZING_PATH}"
             echo "DYLD_LIBRARY_PATH=${SENZING_PATH}/er/lib:${SENZING_PATH}/er/lib/macos"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/maven-darwin.yaml
+++ b/.github/workflows/maven-darwin.yaml
@@ -42,9 +42,7 @@ jobs:
       - name: Build with Maven
         run: |
           # temp update broken file permissions
-          sudo chmod 655 "${SENZING_PATH}/er/resources/templates/G2C.db"
-          sudo chmod 655 "${SENZING_PATH}/er/resources/templates/G2C.db.template"
-          mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pjacoco -Djacoco.haltOnFailure=false -Djacoco.ignoreFailture=true -Dsenzing.support.dir="${SENZING_PATH}/data"
+          mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pjacoco -Djacoco.haltOnFailure=false -Djacoco.ignoreFailture=true
 
       - name: Jacoco Report to PR
         id: jacoco

--- a/src/test/java/com/senzing/nativeapi/InstallLocations.java
+++ b/src/test/java/com/senzing/nativeapi/InstallLocations.java
@@ -160,7 +160,7 @@ public class InstallLocations {
             String[] directoryStructure = { "sz-sdk-java", "java", "g2", "apps", "dev" };
             File workingDir     = new File(System.getProperty("user.dir"));
             File previousDir    = null;
-            boolean devStructure = true;
+            boolean devStructure = (workingDir != null);
             for (String dirName : directoryStructure) {
                 if (workingDir == null)
                     break;
@@ -182,7 +182,11 @@ public class InstallLocations {
             if (senzingPath == null || senzingPath.trim().length() == 0) {
                 senzingPath = System.getenv("SENZING_PATH");
             }
+            if (senzingPath != null && senzingPath.trim().length() == 0) {
+                senzingPath = null;
+            }
 
+            // check if we are in the dev structure with no senzing path defined
             if (devDistDir != null && senzingPath == null) {
                 defaultSenzingPath = devDistDir.getCanonicalPath();
                 defaultInstallPath = devDistDir.getCanonicalPath();
@@ -234,9 +238,6 @@ public class InstallLocations {
             }
 
             // normalize empty strings as null
-            if (senzingPath != null && senzingPath.trim().length() == 0) {
-                senzingPath = null;
-            }
             if (installPath != null && installPath.trim().length() == 0) {
                 installPath = null;
             }
@@ -362,10 +363,11 @@ public class InstallLocations {
             resourceDir = (resourcePath != null) ? new File(resourcePath) : null;
 
             // try the "resources" sub-directory of the installation
-            if (resourceDir == null) {
+            if (resourceDir == null && installDir != null) {
                 resourceDir = new File(installDir, "resources");
-                if (!resourceDir.exists())
+                if (!resourceDir.exists()) {
                     resourceDir = null;
+                }
             }
 
             // set the templates directory if we have the resource directory
@@ -414,7 +416,7 @@ public class InstallLocations {
                 }
 
                 throw new InvalidInstallationException(
-                        "The config directory does not exist or is invalid: " + supportDir);
+                        "The resource directory does not exist or is invalid: " + resourceDir);
             }
 
             // check the senzing config path

--- a/src/test/java/com/senzing/nativeapi/InstallLocations.java
+++ b/src/test/java/com/senzing/nativeapi/InstallLocations.java
@@ -506,7 +506,7 @@ public class InstallLocations {
                 }
 
                 throw new InvalidInstallationException(
-                        "The config directory does not exist or is invalid: " + supportDir
+                        "The config directory does not exist or is invalid: " + configDir
                         + (missingFiles.size() == 0 ? "" : ", missingFiles=[ " + missingFiles + " ]"));
             }
 


### PR DESCRIPTION
Copy/paste error had `supportDir` in place of `configDir` in an error message in the test harness code.

```
               throw new InvalidInstallationException(
                        "The config directory does not exist or is invalid: " + supportDir
                        + (missingFiles.size() == 0 ? "" : ", missingFiles=[ " + missingFiles + " ]"));
```

changed to 

```
               throw new InvalidInstallationException(
                        "The config directory does not exist or is invalid: " + configDir
                        + (missingFiles.size() == 0 ? "" : ", missingFiles=[ " + missingFiles + " ]"));
```