### PR TITLE
Added support for building with Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,48 +149,25 @@
             <goals>
               <goal>java</goal>
             </goals>
-            <configuration>
-              <mainClass>com.senzing.test.GenerateTestJVMScript</mainClass>
-              
-              <target>
-                <property name="maven.classpath" refid="maven.compile.classpath"></property>
-                <property environment="env"/>
-                <condition property="senzing.install.dir"
-                           value="${env.SENZING_DIR}"
-                           else="">
-                  <isset property="env.SENZING_DIR"/>
-                </condition>
-                <condition property="senzing.path"
-                           value="${env.SENZING_PATH}"
-                           else="">
-                  <isset property="env.SENZING_PATH"/>
-                </condition>
-                <condition property="senzing.dev.lib.path"
-                           value="${env.SENZING_DEV_LIBRARY_PATH}"
-                           else="">
-                  <isset property="env.SENZING_DEV_LIBRARY_PATH"/>
-                </condition>
-                <java classname="com.senzing.test.GenerateTestJVMScript">
-                  <classpath>
-                    <pathelement path="${maven.classpath}"></pathelement>
-                    <pathelement location="${project.build.directory}/test-classes/"/>
-                    <pathelement location="${project.build.directory}/classes/"/>
-                  </classpath>
-                  <sysproperty key="senzing.dev.lib.path"
-                               value="${senzing.dev.lib.path}"/>
-                  <sysproperty key="senzing.install.dir"
-                               value="${senzing.install.dir}"/>
-                  <sysproperty key="senzing.path" value="${senzing.path}"/>
-                  <arg value="${project.build.directory}/java-wrapper/bin/java-wrapper.bat"/>
-                </java>
-              </target>
-
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
           </execution>
         </executions>
+        <configuration>
+          <mainClass>com.senzing.test.GenerateTestJVMScript</mainClass>
+          <classpathScope>test</classpathScope>
+          <arguments>
+            <argument>${project.build.directory}/java-wrapper/bin/java-wrapper.bat</argument>
+          </arguments>
+          <systemProperties>
+            <systemProperty>
+              <key>senzing.path</key>
+              <value>${SENZING_PATH}</value>
+            </systemProperty>
+            <systemProperty>
+              <key>senzing.dev.lib.path</key>
+              <value>${SENZING_DEV_LIBRARY_PATH}</value>
+            </systemProperty>
+          </systemProperties>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -140,14 +140,18 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <phase>process-test-classes</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
             <configuration>
-
+              <mainClass>com.senzing.test.GenerateTestJVMScript</mainClass>
+              
               <target>
                 <property name="maven.classpath" refid="maven.compile.classpath"></property>
                 <property environment="env"/>
@@ -183,11 +187,35 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>add-demos</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/demo/java</source>
+              </sources>
+            </configuration>  
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>
           <jvm>${project.build.directory}/java-wrapper/bin/java-wrapper.bat</jvm>
+          <includes>
+            <include>**/*Test.java</include>
+            <include>**/*Tests.java</include>
+            <include>**/*Demo.java</include>
+          </includes>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
           </systemPropertyVariables>
@@ -343,6 +371,45 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java-17</id>
+      <activation>
+        <jdk>17</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <!-- on JDK 17, remove the "@snippet" tag -->
+              <tags>
+                <tag>
+                  <name>snippet</name>
+                  <placement>x</placement>
+                </tag>
+              </tags>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java-18+</id>
+      <activation>
+        <jdk>[18,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <subpackages>com.senzing.sdk</subpackages>
+              <additionalOptions>--snippet-path $(project.basedir)/src/demo/java</additionalOptions>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/src/test/java/com/senzing/nativeapi/InstallLocations.java
+++ b/src/test/java/com/senzing/nativeapi/InstallLocations.java
@@ -506,7 +506,7 @@ public class InstallLocations {
                 }
 
                 throw new InvalidInstallationException(
-                        "The config directory does not exist or is invalid: " + supportDir
+                        "The config directory does not exist or is invalid: " + configDir
                         + (missingFiles.size() == 0 ? "" : ", missingFiles=[ " + missingFiles + " ]"));
             }
 

--- a/src/test/java/com/senzing/test/GenerateTestJVMScript.java
+++ b/src/test/java/com/senzing/test/GenerateTestJVMScript.java
@@ -6,6 +6,8 @@ import static com.senzing.util.OperatingSystemFamily.*;
 
 public class GenerateTestJVMScript {
     public static void main(String[] args) {
+        String homePath = System.getProperty("user.home");
+        File   homeDir  = (homePath == null) ? null : new File(homePath);
         String targetFileName = "target/java-wrapper/bin/java-wrapper.bat";
         if (args.length > 0) {
             targetFileName = args[0];
@@ -19,8 +21,11 @@ public class GenerateTestJVMScript {
         String devLibPath = System.getProperty("senzing.dev.lib.path");
         String senzingDirPath = System.getProperty("senzing.install.dir");
         String senzingPath = System.getProperty("senzing.path");
+        if (senzingPath != null && senzingPath.trim().length() == 0) {
+            senzingPath = null;
+        }
 
-        if (senzingDirPath == null || senzingDirPath.trim().length() == 0
+        if ((senzingDirPath == null || senzingDirPath.trim().length() == 0)
                 && senzingPath != null && senzingPath.trim().length() > 0) {
             File baseDir    = new File(senzingPath);
             File erDir      = new File(baseDir, "er");
@@ -30,6 +35,9 @@ public class GenerateTestJVMScript {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+        }
+        if (senzingDirPath != null && senzingDirPath.trim().length() == 0) {
+            senzingDirPath = null;
         }
 
         String javaHome = System.getProperty("java.home");
@@ -103,8 +111,9 @@ public class GenerateTestJVMScript {
 
         System.out.println("*********************************************");
         System.out.println();
+        System.out.println("senzing.path        = " + senzingPath);
         System.out.println("senzing.install.dir = " + senzingDirPath);
-        System.out.println("java.home = " + javaHome);
+        System.out.println("java.home           = " + javaHome);
         System.out.println();
         System.out.println("*********************************************");
 
@@ -118,6 +127,13 @@ public class GenerateTestJVMScript {
         switch (RUNTIME_OS_FAMILY) {
             case WINDOWS:
                 if (senzingDir == null) {
+                    File baseDir = new File(homeDir, "senzing");
+                    senzingDir = new File(baseDir, "er");
+                    if (!senzingDir.exists()) {
+                        senzingDir = null;
+                    }
+                }
+                if (senzingDir == null) {
                     senzingDir = new File("C:\\Program Files\\Senzing\\er");
                 }
                 libDir = new File(senzingDir, "lib");
@@ -126,7 +142,8 @@ public class GenerateTestJVMScript {
                 break;
             case MAC_OS:
                 if (senzingDir == null) {
-                    senzingDir = new File("/opt/senzing/er");
+                    File baseDir = new File(homeDir, "senzing");
+                    senzingDir = new File(baseDir, "er");
                     if (!senzingDir.exists()) {
                         senzingDir = null;
                     }


### PR DESCRIPTION
Replaced the Maven ant-run plugin with `exec-maven-plugin` to generate the Java wrapper script.

NOTE: Also updated the default Windows and macOS paths in Java wrapper script generator class.

Resolves Issue #106 