### PR TITLE
Updated SzConfig and SzConfigManagger docuemntation and added handling of null config comments.

### DIFF
--- a/src/main/java/com/senzing/sdk/SzConfigManager.java
+++ b/src/main/java/com/senzing/sdk/SzConfigManager.java
@@ -34,10 +34,14 @@ public interface SzConfigManager {
     /**
      * Creates a new {@link SzConfig} instance using the specified
      * configuration definition and returns the {@link SzConfig}
-     * representing that configuration.  Depending upon implementation
-     * of this interface, the specified definition may allow other
-     * forms, but it is typically a JSON-formatted Senzing configuration
-     * (an example template JSON configuration ships with the Senzing product).
+     * representing that configuration.
+     * 
+     * <p>
+     * Depending upon implementation of this interface, the specified
+     * definition may allow other forms, but it is typically a
+     * JSON-formatted Senzing configuration (an example template JSON
+     * configuration ships with the Senzing product).
+     * </p>
      * 
      * <p><b>Usage:</b>
      * {@snippet class="com.senzing.sdk.SzConfigDemo"
@@ -54,9 +58,9 @@ public interface SzConfigManager {
     SzConfig createConfig(String configDefinition) throws SzException;
 
     /**
-     * Gets the configuration definition that is registered with the specified
-     * config ID and returns a new {@link SzConfig} instance representing that
-     * configuration.
+     * Gets the configuration definition that is registered with the
+     * specified config ID and returns a new {@link SzConfig} instance
+     * representing that configuration.
      * 
      * <p><b>Usage:</b>
      * {@snippet class="com.senzing.sdk.SzConfigManagerDemo"
@@ -75,15 +79,24 @@ public interface SzConfigManager {
     SzConfig createConfig(long configId) throws SzException;
 
     /**
-     * Registers the configuration described by the specified JSON in the
-     * repository with the specified comment and returns the identifier for
-     * referencing the the config in the entity repository.
+     * Registers the configuration described by the specified
+     * configuration definition in the repository with the specified
+     * comment and returns the identifier for referencing the the
+     * config in the entity repository.
+     * 
+     * <p>
+     * Depending upon implementation of this interface, the specified
+     * definition may allow other forms, but it is typically a
+     * JSON-formatted Senzing configuration (an example template JSON
+     * configuration ships with the Senzing product).
+     * </p>
      * 
      * <p><b>Usage:</b>
-     * {@snippet class="com.senzing.sdk.SzConfigManagerDemo" region="registerConfigWithComment"}
+     * {@snippet class="com.senzing.sdk.SzConfigManagerDemo"
+     *           region="registerConfigWithComment"}
      * </p>
      *
-     * @param configDefinition The JSON text describing the configuration.
+     * @param configDefinition The configuration definition to register.
      * @param configComment The comments for the configuration.
      * @return The identifier for referencing the config in the entity repository.
      * 
@@ -97,11 +110,18 @@ public interface SzConfigManager {
      * repository with an auto-generated comment and returns the identifier
      * for referencing the the config in the entity repository.
      * 
+     * <p>
+     * Depending upon implementation of this interface, the specified
+     * definition may allow other forms, but it is typically a
+     * JSON-formatted Senzing configuration (an example template JSON
+     * configuration ships with the Senzing product).
+     * </p>
+     * 
      * <p><b>Usage:</b>
      * {@snippet class="com.senzing.sdk.SzConfigManagerDemo" region="registerConfig"}
      * </p>
      *
-     * @param configDefinition The JSON text describing the configuration.
+     * @param configDefinition The configuration definition to register.
      * @return The identifier for referencing the config in the entity repository.
      * 
      * @throws SzException If a failure occurs.
@@ -226,6 +246,13 @@ public interface SzConfigManager {
      * the config ID under which the configuration was registered.
      * 
      * <p>
+     * Depending upon implementation of this interface, the specified
+     * definition may allow other forms, but it is typically a
+     * JSON-formatted Senzing configuration (an example template JSON
+     * configuration ships with the Senzing product).
+     * </p>
+     * 
+     * <p>
      * <b>NOTE:</b> This is best used when initializing the Senzing repository with
      * a registered default config ID the first time (i.e.: when there is no existing
      * default config ID registered).  When there is already a default config ID 
@@ -238,7 +265,7 @@ public interface SzConfigManager {
      *           region="setDefaultConfigWithComment"}
      * </p>
      *
-     * @param configDefinition The JSON text describing the configuration.
+     * @param configDefinition The configuration definition to register as the default.
      * @param configComment The comments for the configuration.
      * 
      * @return The configuration ID under which the configuration was registered.
@@ -250,9 +277,16 @@ public interface SzConfigManager {
     long setDefaultConfig(String configDefinition, String configComment) throws SzException;
 
     /**
-     * Registers the specified config definition with a default-generated comment
+     * Registers the specified config definition with an auto-generated comment
      * and then sets the default configuration ID for the repository to the
      * configuration ID that is the result of that registration.
+     * 
+     * <p>
+     * Depending upon implementation of this interface, the specified
+     * definition may allow other forms, but it is typically a
+     * JSON-formatted Senzing configuration (an example template JSON
+     * configuration ships with the Senzing product).
+     * </p>
      * 
      * <p>
      * <b>NOTE:</b> This is best used when initializing the Senzing repository with
@@ -266,7 +300,7 @@ public interface SzConfigManager {
      * {@snippet class="com.senzing.sdk.SzConfigManagerDemo" region="setDefaultConfig"}
      * </p>
      *
-     * @param configDefinition The JSON text describing the configuration.
+     * @param configDefinition The configuration definition to register as the default.
      * 
      * @return The configuration ID under which the configuration was registered.
      * 
@@ -275,5 +309,4 @@ public interface SzConfigManager {
      * @see <a href="https://raw.githubusercontent.com/Senzing/code-snippets-v4/refs/heads/main/java/snippets/configuration/InitDefaultConfig.java">Code Snippet: Initialize Config</a>
      */
     long setDefaultConfig(String configDefinition) throws SzException;
-
 }

--- a/src/main/java/com/senzing/sdk/core/SzCoreConfigManager.java
+++ b/src/main/java/com/senzing/sdk/core/SzCoreConfigManager.java
@@ -255,9 +255,12 @@ class SzCoreConfigManager implements SzConfigManager {
             // create the result object
             Result<Long> result = new Result<>();
             
+            // handle a null config comment
+            String comment = (configComment == null) ? "" : configComment;
+
             // call the underlying C function
             int returnCode = nativeApi.addConfig(
-                configDefinition, configComment, result);
+                configDefinition, comment, result);
 
             // handle any error code if there is one
             this.env.handleReturnCode(returnCode, this.configMgrApi);
@@ -278,7 +281,7 @@ class SzCoreConfigManager implements SzConfigManager {
      *         length of the character array if no non-whitespace 
      *         character is found.
      */
-    private static int eatWhiteSpace(char[] charArray, int fromIndex) {
+    protected static int eatWhiteSpace(char[] charArray, int fromIndex) {
         int index = fromIndex;
         
         // advance past any whitespace

--- a/src/test/java/com/senzing/sdk/core/SzCoreConfigManagerTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreConfigManagerTest.java
@@ -26,7 +26,6 @@ import com.senzing.sdk.SzConfig;
 import com.senzing.sdk.SzException;
 import com.senzing.sdk.SzConfigManager;
 import com.senzing.sdk.SzReplaceConflictException;
-import com.senzing.util.JsonUtilities;
 
 import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import static org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -312,6 +311,11 @@ public class SzCoreConfigManagerTest extends AbstractTest {
                     
                 SzConfig config = configMgr.createConfig(configId);
 
+                assertNotNull(config, "SzConfig should not be null");
+                
+                assertNotNull(((SzCoreConfig) config).getNativeApi(),
+                      "Underlying native API is unexpectedly null");
+                
                 String configDefinition = config.export();
 
                 assertEquals(expectedDefinition, configDefinition, 

--- a/src/test/java/com/senzing/sdk/core/SzCoreConfigTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreConfigTest.java
@@ -103,10 +103,10 @@ public class SzCoreConfigTest extends AbstractTest {
         }
 
         this.env = SzCoreEnvironment.newBuilder()
-                                      .instanceName(instanceName)
-                                      .settings(settings)
-                                      .verboseLogging(false)
-                                      .build();
+                                    .instanceName(instanceName)
+                                    .settings(settings)
+                                    .verboseLogging(false)
+                                    .build();
     }
 
     @AfterAll
@@ -133,7 +133,7 @@ public class SzCoreConfigTest extends AbstractTest {
                 // expected
 
             } catch (Exception e) {
-                fail("Failed testGetNativeApi test with exception", e);
+                fail("Failed testNullDefinitionConstruct test with exception", e);
             }
         });
     }
@@ -150,7 +150,7 @@ public class SzCoreConfigTest extends AbstractTest {
                 // expected
 
             } catch (Exception e) {
-                fail("Failed testGetNativeApi test with exception", e);
+                fail("Failed testNullEnvironmentConstruct test with exception", e);
             }
         });
     }
@@ -181,6 +181,9 @@ public class SzCoreConfigTest extends AbstractTest {
 
                 assertNotNull(config, "SzConfig should not be null");
                 
+                assertNotNull(((SzCoreConfig) config).getNativeApi(),
+                      "Underlying native API is unexpectedly null");
+
                 String configJson = config.export();
                 
                 assertEquals(this.defaultConfig, configJson, "Unexpected configuration definition.");
@@ -201,6 +204,9 @@ public class SzCoreConfigTest extends AbstractTest {
 
                 assertNotNull(config, "SzConfig should not be null");
 
+                assertNotNull(((SzCoreConfig) config).getNativeApi(),
+                      "Underlying native API is unexpectedly null");
+                      
                 String configJson = config.export();
                 
                 assertEquals(this.modifiedConfig, configJson, "Unexpected configuration definition.");


### PR DESCRIPTION
- Continued work on Issue #121 
- Modifications to support handling a `null` config comment in SzConfigManager (for relevant functions) and treating that as an empty string comment.
- Fixed documentation for `SzConfig` and `SzConfigManager`
