### PR TITLE
Previously unsaved file with minor documentation change for why-search

### DIFF
--- a/src/main/java/com/senzing/sdk/SzEngine.java
+++ b/src/main/java/com/senzing/sdk/SzEngine.java
@@ -427,7 +427,8 @@ public interface SzEngine {
      *              SzFlag#SZ_NO_FLAGS} or {@link SzFlag#SZ_WHY_SEARCH_DEFAULT_FLAGS}
      *              for the default recommended flags.
      * 
-     * @return The resulting JSON {@link String} describing the result of the search.
+     * @return The resulting JSON {@link String} describing the result of the
+     *         why analysis against the search critieria.
      * 
      * 
      * @throws SzNotFoundException If no entity could be found with the


### PR DESCRIPTION
I had an unsaved change to `SzEngine.java` which missed the last pull request for the documentation on `whySearch()`.  This pull-request corrects that.