### PR TITLE
#147: Added flag tests based on meta-data made flag groups more granular

### DIFF
--- a/src/main/java/com/senzing/sdk/SzEngine.java
+++ b/src/main/java/com/senzing/sdk/SzEngine.java
@@ -59,8 +59,8 @@ public interface SzEngine {
      * <p>
      * The specified {@link Set} of {@link SzFlag} instances may contain any 
      * {@link SzFlag} value, but only flags belonging to the {@link
-     * SzFlagUsageGroup#SZ_MODIFY_FLAGS} group will be recognized (other {@link SzFlag}
-     * instances will be ignored).  <b>NOTE:</b> {@link java.util.EnumSet}
+     * SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS} group will be recognized (other 
+     * {@link SzFlag} instances will be ignored).  <b>NOTE:</b> {@link java.util.EnumSet}
      * offers an efficient means of constructing a {@link Set} of {@link SzFlag}.
      * 
      * <p><b>Usage:</b>
@@ -74,10 +74,11 @@ public interface SzEngine {
      *                         in JSON format.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} group to control how
-     *              the operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
-     *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
+     *              to the {@link SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS} group to
+     *              control how the operation is performed and the content of the
+     *              response, or <code>null</code> to default to {@link
+     *              SzFlag#SZ_NO_FLAGS}.  Specify {@link SzFlag#SZ_WITH_INFO_FLAGS}
+     *              for an INFO response.
      * 
      * @return The JSON {@link String} result produced by adding the record to the
      *         repository, or <code>null</code> if the specified flags do not 
@@ -93,7 +94,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WITH_INFO_FLAGS
-     * @see SzFlagUsageGroup#SZ_MODIFY_FLAGS
+     * @see SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS
      * 
      * @see <a href="https://raw.githubusercontent.com/Senzing/code-snippets-v4/refs/heads/main/java/snippets/loading/LoadRecords.java">Code Snippet: Load Records</a>
      * @see <a href="https://raw.githubusercontent.com/Senzing/code-snippets-v4/refs/heads/main/java/snippets/loading/LoadTruthSetWithInfoViaLoop.java">Code Snippet: Load Truth Set "With Info"</a>
@@ -155,9 +156,10 @@ public interface SzEngine {
      * <p>
      * The specified {@link Set} of {@link SzFlag} instances may contain any 
      * {@link SzFlag} value, but only flags belonging to the {@link
-     * SzFlagUsageGroup#SZ_MODIFY_FLAGS} group will be recognized (other {@link SzFlag}
-     * instances will be ignored).  <b>NOTE:</b> {@link java.util.EnumSet}
-     * offers an efficient means of constructing a {@link Set} of {@link SzFlag}.
+     * SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS} group will be recognized
+     * (other {@link SzFlag} instances will be ignored).  <b>NOTE:</b>
+     * {@link java.util.EnumSet} offers an efficient means of constructing
+     * a {@link Set} of {@link SzFlag}.
      * 
      * <p><b>Usage:</b>
      * {@snippet class="com.senzing.sdk.SzEngineDemo" region="deleteRecord"}
@@ -167,10 +169,11 @@ public interface SzEngine {
      *                  data source code and record Id of the record to delete.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} group to control how
-     *              the operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
-     *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
+     *              to the {@link SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS} group to
+     *              control how the operation is performed and the content of the
+     *              response, or <code>null</code> to default to {@link
+     *              SzFlag#SZ_NO_FLAGS}.  Specify {@link SzFlag#SZ_WITH_INFO_FLAGS}
+     *              for an INFO response.
      *
      * @return The JSON {@link String} result produced by deleting the record from
      *         the repository, or <code>null</code> if the specified flags do not 
@@ -182,7 +185,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WITH_INFO_FLAGS
-     * @see SzFlagUsageGroup#SZ_MODIFY_FLAGS
+     * @see SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS
      * @see <a href="https://raw.githubusercontent.com/Senzing/code-snippets-v4/refs/heads/main/java/snippets/deleting/DeleteViaLoop.java">Code Snippet: Delete via Loop</a>
      * @see <a href="https://raw.githubusercontent.com/Senzing/code-snippets-v4/refs/heads/main/java/snippets/deleting/DeleteViaFutures.java">Code Snippet: Delete via Futures</a>
      * @see <a href="https://raw.githubusercontent.com/Senzing/code-snippets-v4/refs/heads/main/java/snippets/deleting/DeleteWithInfoViaFutures.java">Code Snippet: Delete "With Info" via Futures</a>
@@ -204,9 +207,10 @@ public interface SzEngine {
      * <p>
      * The specified {@link Set} of {@link SzFlag} instances may contain any 
      * {@link SzFlag} value, but only flags belonging to the {@link
-     * SzFlagUsageGroup#SZ_MODIFY_FLAGS} group will be recognized (other {@link SzFlag}
-     * instances will be ignored).  <b>NOTE:</b> {@link java.util.EnumSet}
-     * offers an efficient means of constructing a {@link Set} of {@link SzFlag}.
+     * SzFlagUsageGroup#SZ_REEVALUATE_FLAGS} group will be recognized (other
+     * {@link SzFlag} instances will be ignored).  <b>NOTE:</b>
+     * {@link java.util.EnumSet} offers an efficient means of constructing a
+     * {@link Set} of {@link SzFlag}.
      * 
      * <p><b>Usage:</b>
      * {@snippet class="com.senzing.sdk.SzEngineDemo" region="reevaluateRecord"}
@@ -216,7 +220,7 @@ public interface SzEngine {
      *                  data source code and record Id of the record to reevaluate.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} group to control how
+     *              to the {@link SzFlagUsageGroup#SZ_REEVALUATE_FLAGS} group to control how
      *              the operation is performed and the content of the response, or
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
      *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
@@ -231,7 +235,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WITH_INFO_FLAGS
-     * @see SzFlagUsageGroup#SZ_MODIFY_FLAGS
+     * @see SzFlagUsageGroup#SZ_REEVALUATE_FLAGS
      */
     String reevaluateRecord(SzRecordKey recordKey, Set<SzFlag> flags)
         throws SzUnknownDataSourceException, SzException;
@@ -247,9 +251,10 @@ public interface SzEngine {
      * <p>
      * The specified {@link Set} of {@link SzFlag} instances may contain any 
      * {@link SzFlag} value, but only flags belonging to the {@link
-     * SzFlagUsageGroup#SZ_MODIFY_FLAGS} group will be recognized (other {@link SzFlag}
-     * instances will be ignored).  <b>NOTE:</b> {@link java.util.EnumSet}
-     * offers an efficient means of constructing a {@link Set} of {@link SzFlag}.
+     * SzFlagUsageGroup#SZ_REEVALUATE_FLAGS} group will be recognized (other
+     * {@link SzFlag} instances will be ignored).  <b>NOTE:</b> {@link
+     * java.util.EnumSet} offers an efficient means of constructing a {@link Set}
+     * of {@link SzFlag}.
      * 
      * <p><b>Usage:</b>
      * {@snippet class="com.senzing.sdk.SzEngineDemo" region="reevaluateEntity"}
@@ -258,10 +263,11 @@ public interface SzEngine {
      * @param entityId The ID of the resolved entity to reevaluate.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} group to control how
-     *              the operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
-     *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
+     *              to the {@link SzFlagUsageGroup#SZ_REEVALUATE_FLAGS} group to
+     *              control how the operation is performed and the content of the
+     *              response, or <code>null</code> to default to {@link
+     *              SzFlag#SZ_NO_FLAGS}.  Specify {@link SzFlag#SZ_WITH_INFO_FLAGS}
+     *              for an INFO response.
      *
      * @return The JSON {@link String} result produced by reevaluating the entity
      *         in the repository, or <code>null</code> if the specified flags do
@@ -270,7 +276,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WITH_INFO_FLAGS
-     * @see SzFlagUsageGroup#SZ_MODIFY_FLAGS
+     * @see SzFlagUsageGroup#SZ_REEVALUATE_FLAGS
      */
     String reevaluateEntity(long entityId, Set<SzFlag> flags)
         throws SzException;
@@ -929,9 +935,9 @@ public interface SzEngine {
      * not only control how the operation is performed but also the level of
      * detail provided for the entity and record being analyzed.  The
      * {@link Set} may contain any {@link SzFlag} value, but only flags
-     * belonging to the {@link SzFlagUsageGroup#SZ_WHY_FLAGS} group are guaranteed
-     * to be recognized (other {@link SzFlag} instances will be ignored unless
-     * they have equivalent bit flags).
+     * belonging to the {@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
+     * group are guaranteed to be recognized (other {@link SzFlag} instances
+     * will be ignored unless they have equivalent bit flags).
      * <p>
      * <b>NOTE:</b> {@link java.util.EnumSet} offers an efficient means of
      * constructing a {@link Set} of {@link SzFlag}.
@@ -944,11 +950,11 @@ public interface SzEngine {
      *                  and record ID identifying the record.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_WHY_FLAGS} group to control how the
-     *              operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}
-     *              or {@link SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS} for the
-     *              default recommended flags.
+     *              to the {@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
+     *              group to control how the operation is performed and the content
+     *              of the response, or <code>null</code> to default to {@link
+     *              SzFlag#SZ_NO_FLAGS} or {@link SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS}
+     *              for the default recommended flags.
      * 
      * @return The JSON {@link String} describing why the record is included
      *         in its respective entity.
@@ -963,7 +969,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS
-     * @see SzFlagUsageGroup#SZ_WHY_FLAGS
+     * @see SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS
      * 
      * @see #whyEntities(long, long, Set)
      * @see #whyRecords(SzRecordKey, SzRecordKey, Set)
@@ -980,9 +986,9 @@ public interface SzEngine {
      * not only control how the operation is performed but also the level of
      * detail provided for the entity and record being analyzed.  The
      * {@link Set} may contain any {@link SzFlag} value, but only flags
-     * belonging to the {@link SzFlagUsageGroup#SZ_WHY_FLAGS} group are guaranteed
-     * to be recognized (other {@link SzFlag} instances will be ignored unless
-     * they have equivalent bit flags).
+     * belonging to the {@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS} group
+     * are guaranteed to be recognized (other {@link SzFlag} instances will
+     * be ignored unless they have equivalent bit flags).
      * <p>
      * <b>NOTE:</b> {@link java.util.EnumSet} offers an efficient means of
      * constructing a {@link Set} of {@link SzFlag}.
@@ -998,7 +1004,8 @@ public interface SzEngine {
      *                   data source code and record ID for the second record.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_WHY_FLAGS} group to control how the
+     *              to the {@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS} group to
+     *        control how the
      *              operation is performed and the content of the response, or
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}
      *              or {@link SzFlag#SZ_WHY_RECORDS_DEFAULT_FLAGS} for the
@@ -1017,7 +1024,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WHY_RECORDS_DEFAULT_FLAGS
-     * @see SzFlagUsageGroup#SZ_WHY_FLAGS
+     * @see SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS
      * 
      * @see #whyRecordInEntity(SzRecordKey, Set)
      * @see #whyEntities(long, long, Set)
@@ -1035,9 +1042,9 @@ public interface SzEngine {
      * not only control how the operation is performed but also the level of
      * detail provided for the entity and record being analyzed.  The
      * {@link Set} may contain any {@link SzFlag} value, but only flags
-     * belonging to the {@link SzFlagUsageGroup#SZ_WHY_FLAGS} group are guaranteed
-     * to be recognized (other {@link SzFlag} instances will be ignored unless
-     * they have equivalent bit flags).
+     * belonging to the {@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS} group
+     * are guaranteed to be recognized (other {@link SzFlag} instances will
+     * be ignored unless they have equivalent bit flags).
      * <p>
      * <b>NOTE:</b> {@link java.util.EnumSet} offers an efficient means of
      * constructing a {@link Set} of {@link SzFlag}.
@@ -1051,9 +1058,9 @@ public interface SzEngine {
      * @param entityId2 The entity ID of the second entity.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_WHY_FLAGS} group to control how the
-     *              operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}
+     *              to the {@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS} group to
+     *              control how the operation is performed and the content of the
+     *              response, or <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}
      *              or {@link SzFlag#SZ_WHY_ENTITIES_DEFAULT_FLAGS} for the
      *              default recommended flags.
      * 
@@ -1066,7 +1073,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WHY_ENTITIES_DEFAULT_FLAGS
-     * @see SzFlagUsageGroup#SZ_WHY_FLAGS
+     * @see SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS
      * 
      * @see #whyRecords(SzRecordKey, SzRecordKey, Set)
      * @see #whyRecordInEntity(SzRecordKey, Set)
@@ -1367,7 +1374,7 @@ public interface SzEngine {
      * not only control how the operation is performed but also the level of
      * detail provided for the entity and record being analyzed.  The
      * {@link Set} may contain any {@link SzFlag} value, but only flags
-     * belonging to the {@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} group are
+     * belonging to the {@link SzFlagUsageGroup#SZ_REDO_FLAGS} group are
      * guaranteed to be recognized (other {@link SzFlag} instances will be
      * ignored unless they have equivalent bit flags).
      * <p>
@@ -1381,7 +1388,7 @@ public interface SzEngine {
      * @param redoRecord The redo record to be processed.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} group to control how
+     *              to the {@link SzFlagUsageGroup#SZ_REDO_FLAGS} group to control how
      *              the operation is performed and the content of the response, or
      *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
      *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
@@ -1393,7 +1400,7 @@ public interface SzEngine {
      * @throws SzException If a failure occurs.
      * 
      * @see SzFlag#SZ_WITH_INFO_FLAGS
-     * @see SzFlagUsageGroup#SZ_MODIFY_FLAGS
+     * @see SzFlagUsageGroup#SZ_REDO_FLAGS
      * 
      * @see #getRedoRecord()
      * @see #countRedoRecords()

--- a/src/main/java/com/senzing/sdk/SzEngine.java
+++ b/src/main/java/com/senzing/sdk/SzEngine.java
@@ -77,7 +77,7 @@ public interface SzEngine {
      *              to the {@link SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS} group to
      *              control how the operation is performed and the content of the
      *              response, or <code>null</code> to default to {@link
-     *              SzFlag#SZ_NO_FLAGS}.  Specify {@link SzFlag#SZ_WITH_INFO_FLAGS}
+     *              SzFlag#SZ_NO_FLAGS} or {@link SzFlag#SZ_WITH_INFO_FLAGS}
      *              for an INFO response.
      * 
      * @return The JSON {@link String} result produced by adding the record to the
@@ -116,9 +116,10 @@ public interface SzEngine {
      * <p>
      * The specified {@link Set} of {@link SzFlag} instances may contain any 
      * {@link SzFlag} value, but only flags belonging to the {@link
-     * SzFlagUsageGroup#SZ_RECORD_FLAGS} group will be recognized (other {@link SzFlag}
-     * instances will be ignored).  <b>NOTE:</b> {@link java.util.EnumSet}
-     * offers an efficient means of constructing a {@link Set} of {@link SzFlag}.
+     * SzFlagUsageGroup#SZ_RECORD_FLAGS} group will be recognized
+     * (other {@link SzFlag} instances will be ignored).
+     * <b>NOTE:</b> {@link java.util.EnumSet} offers an efficient means of
+     * constructing a {@link Set} of {@link SzFlag}.
      * 
      * <p><b>Usage:</b>
      * {@snippet class="com.senzing.sdk.SzEngineDemo" region="preprocessRecord"}
@@ -128,10 +129,11 @@ public interface SzEngine {
      *                         in JSON format.
      * 
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
-     *              to the {@link SzFlagUsageGroup#SZ_RECORD_FLAGS} group to control how
-     *              the operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link 
-     *              SzFlag#SZ_RECORD_DEFAULT_FLAGS}.
+     *              to the {@link SzFlagUsageGroup#SZ_RECORD_FLAGS} group
+     *              to control how the operation is performed and the content of the
+     *              response, or <code>null</code> to default to {@link 
+     *              SzFlag#SZ_NO_FLAGS} or {@link SzFlag#SZ_RECORD_DEFAULT_FLAGS} 
+     *              for the default recommended flags.
      * 
      * @return The JSON {@link String} result produced by preprocessing the record
      *         (depending on the specified flags).
@@ -172,7 +174,7 @@ public interface SzEngine {
      *              to the {@link SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS} group to
      *              control how the operation is performed and the content of the
      *              response, or <code>null</code> to default to {@link
-     *              SzFlag#SZ_NO_FLAGS}.  Specify {@link SzFlag#SZ_WITH_INFO_FLAGS}
+     *              SzFlag#SZ_NO_FLAGS} or {@link SzFlag#SZ_WITH_INFO_FLAGS}
      *              for an INFO response.
      *
      * @return The JSON {@link String} result produced by deleting the record from
@@ -222,8 +224,8 @@ public interface SzEngine {
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
      *              to the {@link SzFlagUsageGroup#SZ_REEVALUATE_FLAGS} group to control how
      *              the operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
-     *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
+     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS} or
+     *              {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
      *
      * @return The JSON {@link String} result produced by reevaluating the record
      *         in the repository, or <code>null</code> if the specified flags do
@@ -266,7 +268,7 @@ public interface SzEngine {
      *              to the {@link SzFlagUsageGroup#SZ_REEVALUATE_FLAGS} group to
      *              control how the operation is performed and the content of the
      *              response, or <code>null</code> to default to {@link
-     *              SzFlag#SZ_NO_FLAGS}.  Specify {@link SzFlag#SZ_WITH_INFO_FLAGS}
+     *              SzFlag#SZ_NO_FLAGS} or {@link SzFlag#SZ_WITH_INFO_FLAGS}
      *              for an INFO response.
      *
      * @return The JSON {@link String} result produced by reevaluating the entity
@@ -1390,8 +1392,8 @@ public interface SzEngine {
      * @param flags The optional {@link Set} of {@link SzFlag} instances belonging
      *              to the {@link SzFlagUsageGroup#SZ_REDO_FLAGS} group to control how
      *              the operation is performed and the content of the response, or
-     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS}.
-     *              Specify {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
+     *              <code>null</code> to default to {@link SzFlag#SZ_NO_FLAGS} or
+     *              {@link SzFlag#SZ_WITH_INFO_FLAGS} for an INFO response.
      * 
      * @return The JSON {@link String} result produced by processing the redo record
      *         in the repository, or <code>null</code> if the specified flags do not 

--- a/src/main/java/com/senzing/sdk/SzFlag.java
+++ b/src/main/java/com/senzing/sdk/SzFlag.java
@@ -32,7 +32,10 @@ public enum SzFlag {
      * <p>
      * This flag belongs to the following usage groups:
      * <ul>
-     *    <li>{@link SzFlagUsageGroup#SZ_MODIFY_FLAGS} 
+     *     <li>{@link SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS}
+     *     <li>{@link SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS}
+     *     <li>{@link SzFlagUsageGroup#SZ_REEVALUATE_FLAGS}
+     *     <li>{@link SzFlagUsageGroup#SZ_REDO_FLAGS}
      * </ul>
      */
     SZ_WITH_INFO(SzFlags.SZ_WITH_INFO, SZ_MODIFY_SET),
@@ -125,7 +128,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -142,7 +147,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -159,7 +166,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -176,7 +185,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -193,7 +204,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -211,7 +224,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -229,7 +244,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -247,7 +264,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -266,7 +285,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -284,7 +305,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -303,7 +326,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -322,7 +347,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -341,7 +368,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -360,7 +389,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -382,7 +413,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -405,7 +438,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -424,7 +459,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -442,7 +479,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -459,7 +498,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -476,7 +517,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -494,7 +537,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -513,7 +558,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -532,7 +579,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_VIRTUAL_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -548,10 +597,13 @@ public enum SzFlag {
      * <ul>
      *    <li>{@link SzFlagUsageGroup#SZ_ENTITY_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_SEARCH_FLAGS} 
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_SEARCH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_HOW_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
@@ -604,7 +656,9 @@ public enum SzFlag {
      * This flag belongs to the following usage groups:
      * <ul>
      *    <li>{@link SzFlagUsageGroup#SZ_SEARCH_FLAGS}
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_WHY_SEARCH_FLAGS}
      *    <li>{@link SzFlagUsageGroup#SZ_HOW_FLAGS}
      * </ul>
@@ -736,13 +790,43 @@ public enum SzFlag {
     /**
      * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
      * containing all {@link SzFlag} instances belonging to the {@link 
-     * SzFlagUsageGroup#SZ_MODIFY_FLAGS} usage group.
+     * SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS} usage group.
      * 
-     * @see SzFlagUsageGroup#SZ_MODIFY_FLAGS
+     * @see SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS
      */
-    public static final Set<SzFlag> SZ_MODIFY_ALL_FLAGS
+    public static final Set<SzFlag> SZ_ADD_RECORD_ALL_FLAGS
         = Collections.unmodifiableSet(EnumSet.of(SZ_WITH_INFO));
         
+    /**
+     * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
+     * containing all {@link SzFlag} instances belonging to the {@link 
+     * SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS} usage group.
+     * 
+     * @see SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS
+     */
+    public static final Set<SzFlag> SZ_DELETE_RECORD_ALL_FLAGS
+        = Collections.unmodifiableSet(EnumSet.of(SZ_WITH_INFO));
+
+    /**
+     * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
+     * containing all {@link SzFlag} instances belonging to the {@link 
+     * SzFlagUsageGroup#SZ_REEVALUATE_FLAGS} usage group.
+     * 
+     * @see SzFlagUsageGroup#SZ_REEVALUATE_FLAGS
+     */
+    public static final Set<SzFlag> SZ_REEVALUATE_ALL_FLAGS
+        = Collections.unmodifiableSet(EnumSet.of(SZ_WITH_INFO));
+
+    /**
+     * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
+     * containing all {@link SzFlag} instances belonging to the {@link 
+     * SzFlagUsageGroup#SZ_REDO_FLAGS} usage group.
+     * 
+     * @see SzFlagUsageGroup#SZ_REDO_FLAGS
+     */
+    public static final Set<SzFlag> SZ_REDO_ALL_FLAGS
+        = Collections.unmodifiableSet(EnumSet.of(SZ_WITH_INFO));
+
     /**
      * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
      * containing all {@link SzFlag} instances belonging to the
@@ -880,17 +964,49 @@ public enum SzFlag {
     /**
      * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
      * containing all {@link SzFlag} instances belonging to the
-     * {@link SzFlagUsageGroup#SZ_WHY_FLAGS} usage group.
+     * {@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS} usage group.
      * 
-     * @see SzFlagUsageGroup#SZ_WHY_FLAGS
+     * @see SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS
      */
-    public static final Set<SzFlag> SZ_WHY_ALL_FLAGS;
+    public static final Set<SzFlag> SZ_WHY_RECORDS_ALL_FLAGS;
     
     static {
         Set<SzFlag> flagSet = EnumSet.noneOf(SzFlag.class);
         flagSet.addAll(SZ_ENTITY_ALL_FLAGS);
         flagSet.add(SZ_INCLUDE_FEATURE_SCORES);
-        SZ_WHY_ALL_FLAGS = Collections.unmodifiableSet(flagSet);
+        SZ_WHY_RECORDS_ALL_FLAGS = Collections.unmodifiableSet(flagSet);
+    }
+
+    /**
+     * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
+     * containing all {@link SzFlag} instances belonging to the
+     * {@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS} usage group.
+     * 
+     * @see SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS
+     */
+    public static final Set<SzFlag> SZ_WHY_ENTITIES_ALL_FLAGS;
+    
+    static {
+        Set<SzFlag> flagSet = EnumSet.noneOf(SzFlag.class);
+        flagSet.addAll(SZ_ENTITY_ALL_FLAGS);
+        flagSet.add(SZ_INCLUDE_FEATURE_SCORES);
+        SZ_WHY_ENTITIES_ALL_FLAGS = Collections.unmodifiableSet(flagSet);
+    }
+
+    /**
+     * The <b>unmodifiable</b> {@link Set} of {@link SzFlag} instances
+     * containing all {@link SzFlag} instances belonging to the
+     * {@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS} usage group.
+     * 
+     * @see SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS
+     */
+    public static final Set<SzFlag> SZ_WHY_RECORD_IN_ENTITY_ALL_FLAGS;
+    
+    static {
+        Set<SzFlag> flagSet = EnumSet.noneOf(SzFlag.class);
+        flagSet.addAll(SZ_ENTITY_ALL_FLAGS);
+        flagSet.add(SZ_INCLUDE_FEATURE_SCORES);
+        SZ_WHY_RECORD_IN_ENTITY_ALL_FLAGS = Collections.unmodifiableSet(flagSet);
     }
 
     /**
@@ -969,7 +1085,10 @@ public enum SzFlag {
      * <p>
      * All the flags in this {@link Set} belong to the following usage groups:
      * <ul>
-     *     <li>{@link SzFlagUsageGroup#SZ_MODIFY_FLAGS}
+     *     <li>{@link SzFlagUsageGroup#SZ_ADD_RECORD_FLAGS}
+     *     <li>{@link SzFlagUsageGroup#SZ_DELETE_RECORD_FLAGS}
+     *     <li>{@link SzFlagUsageGroup#SZ_REEVALUATE_FLAGS}
+     *     <li>{@link SzFlagUsageGroup#SZ_REDO_FLAGS}
      * </ul> 
      */
     public static final Set<SzFlag> SZ_WITH_INFO_FLAGS
@@ -1043,7 +1162,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -1098,7 +1219,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS}
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -1131,7 +1254,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -1165,7 +1290,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -1200,7 +1327,9 @@ public enum SzFlag {
      *    <li>{@link SzFlagUsageGroup#SZ_EXPORT_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_PATH_FLAGS} 
      *    <li>{@link SzFlagUsageGroup#SZ_FIND_NETWORK_FLAGS} 
-     *    <li>{@link SzFlagUsageGroup#SZ_WHY_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS}
+     *    <li>{@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS}
      * </ul>
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -1291,7 +1420,7 @@ public enum SzFlag {
      * </ul>
      * <p>
      * All the flags in this {@link Set} are guaranteed to belong to the
-     * {@link SzFlagUsageGroup#SZ_WHY_FLAGS} usage group.
+     * {@link SzFlagUsageGroup#SZ_WHY_ENTITIES_FLAGS} usage group.
      *
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -1308,7 +1437,7 @@ public enum SzFlag {
      * </ul>
      * <p>
      * All the flags in this {@link Set} are guaranteed to belong to the
-     * {@link SzFlagUsageGroup#SZ_WHY_FLAGS} usage group.
+     * {@link SzFlagUsageGroup#SZ_WHY_RECORDS_FLAGS} usage group.
      *
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
@@ -1325,7 +1454,7 @@ public enum SzFlag {
      * </ul>
      * <p>
      * All the flags in this {@link Set} are guaranteed to belong to the
-     * {@link SzFlagUsageGroup#SZ_WHY_FLAGS} usage group.
+     * {@link SzFlagUsageGroup#SZ_WHY_RECORD_IN_ENTITY_FLAGS} usage group.
      *
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */

--- a/src/main/java/com/senzing/sdk/SzFlag.java
+++ b/src/main/java/com/senzing/sdk/SzFlag.java
@@ -611,7 +611,7 @@ public enum SzFlag {
      * @see <a href="https://docs.senzing.com/flags/index.html">https://docs.senzing.com/flags/index.html</a>
      */
     SZ_INCLUDE_FEATURE_SCORES(
-        SzFlags.SZ_INCLUDE_FEATURE_SCORES, SZ_HOW_WHY_SET),
+        SzFlags.SZ_INCLUDE_FEATURE_SCORES, SZ_HOW_WHY_SEARCH_SET),
 
     /**
      * The value for including statistics from search results.
@@ -843,6 +843,8 @@ public enum SzFlag {
     static {
         Set<SzFlag> flagSet = EnumSet.noneOf(SzFlag.class);
         flagSet.addAll(SZ_ENTITY_ALL_FLAGS);
+        flagSet.add(SZ_INCLUDE_MATCH_KEY_DETAILS);
+        flagSet.add(SZ_INCLUDE_FEATURE_SCORES);
         flagSet.add(SZ_SEARCH_INCLUDE_STATS);
         flagSet.add(SZ_SEARCH_INCLUDE_RESOLVED);
         flagSet.add(SZ_SEARCH_INCLUDE_POSSIBLY_SAME);

--- a/src/main/java/com/senzing/sdk/SzFlagHelpers.java
+++ b/src/main/java/com/senzing/sdk/SzFlagHelpers.java
@@ -64,10 +64,10 @@ final class SzFlagHelpers {
         
     /**
      * The package-private <b>unmodifiable</b> empty {@link Set} of {@link 
-     * SzFlagUsageGroup} that proxies for {@link SzFlagUsageGroup#SZ_HOW_WHY_SET}
+     * SzFlagUsageGroup} that proxies for {@link SzFlagUsageGroup#SZ_HOW_WHY_SEARCH_SET}
      * to help with circular dependencies during initialization.
      */
-    static final Set<SzFlagUsageGroup> SZ_HOW_WHY_SET 
+    static final Set<SzFlagUsageGroup> SZ_HOW_WHY_SEARCH_SET 
         = Collections.unmodifiableSet(new TreeSet<>());
     
     /**

--- a/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
+++ b/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
@@ -14,20 +14,69 @@ import static com.senzing.sdk.Utilities.hexFormat;
  */
 public enum SzFlagUsageGroup {
     /**
-     * Flags in this usage group can be used for operations that modify the
-     * entity repository by adding records, revaluating records or entities,
-     * deleting records or any similar operations.
+     * Flags in this usage group can be used for operations that add
+     * records to the entity repository.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#addRecord(SzRecordKey, String, Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
      *      <li>{@link SzFlag#SZ_WITH_INFO}
      * </ul>
      */
-    SZ_MODIFY_FLAGS,
+    SZ_ADD_RECORD_FLAGS,
+
+    /**
+     * Flags in this usage group can be used for operations that delete
+     * records from the entity repository.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#deleteRecord(SzRecordKey, Set)}</li>
+     * </ul>
+     * <p>
+     * The {@link SzFlag} instances included in this usage group are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_WITH_INFO}
+     * </ul>
+     */
+    SZ_DELETE_RECORD_FLAGS,
+
+    /**
+     * Flags in this usage group can be used for operations that reevaluate
+     * records or entities from the entity repository.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#reevaluateRecord(SzRecordKey, Set)}</li>
+     *  <li>{@link SzEngine#reevaluateEntity(long, Set)}</li>
+     * </ul>
+     * <p>
+     * The {@link SzFlag} instances included in this usage group are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_WITH_INFO}
+     * </ul>
+     */
+    SZ_REEVALUATE_FLAGS,
+
+    /**
+     * Flags in this usage group can be used for operations that process
+     * redo records in the entity repository.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#processRedoRecord(String, Set)}</li>
+     * </ul>
+     * <p>
+     * The {@link SzFlag} instances included in this usage group are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_WITH_INFO}
+     * </ul>
+     */
+    SZ_REDO_FLAGS,
 
     /**
      * Flags in this usage group can be used for operations that retrieve record
      * data in order to control the level of detail of the returned record.
+     * Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#getRecord(SzRecordKey, Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -50,7 +99,12 @@ public enum SzFlagUsageGroup {
     /**
      * Flags in this usage group can be used for operations that retrieve
      * entity data in order to control the level of detail of the returned
-     * entity.
+     * entity.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#getEntity(long, Set)}</li>
+     *  <li>{@link SzEngine#getEntity(SzRecordKey, Set)}</li>
+     * </ul>
+     * <p>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -100,7 +154,11 @@ public enum SzFlagUsageGroup {
      * Flags in this usage group can be used to control the methodology for
      * finding an entity path, what details to include for the entity 
      * path and the level of detail for the entities on the path that
-     * are returned.
+     * are returned.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#findPath(long,long,int,SzEntityIds,Set,Set)}</li>
+     *  <li>{@link SzEngine#findPath(SzRecordKey,SzRecordKey,int,SzRecordKeys,Set,Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -154,7 +212,11 @@ public enum SzFlagUsageGroup {
      * Flags in this usage group can be used to control the methodology for
      * finding an entity network, what details to include for the entity 
      * network and the level of detail for the entities in the network
-     * that are returned.
+     * that are returned.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#findNetwork(SzEntityIds,int,int,int,Set)}</li>
+     *  <li>{@link SzEngine#findNetwork(SzRecordKeys,int,int,int,Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -207,7 +269,11 @@ public enum SzFlagUsageGroup {
      * Flags in this usage group can be used for operations that search for 
      * entities to control how the entities are qualified for inclusion
      * in the search results and the level of detail for the entities
-     * returned in the search results.
+     * returned in the search results.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#searchByAttributes(String,String,Set)}</li>
+     *  <li>{@link SzEngine#searchByAttributes(String,Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -273,7 +339,11 @@ public enum SzFlagUsageGroup {
      * Flags in this usage group can be used for operations that export 
      * entities to control how the entities are qualified for inclusion
      * in the export and the level of detail for the entities returned
-     * in the search results.
+     * in the search results.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#exportJsonEntityReport(Set)}</li>
+     *  <li>{@link SzEngine#exportCsvEntityReport(String,Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -331,7 +401,10 @@ public enum SzFlagUsageGroup {
      * Flags in this usage group can be used to control the methodology for
      * performing "why analysis", what details to include for the analysis
      * and the level of detail for the entities in the network that are 
-     * returned.
+     * returned.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#whyRecordInEntity(SzRecordKey, Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -380,13 +453,132 @@ public enum SzFlagUsageGroup {
      *      <li>{@link SzFlag#SZ_VIRTUAL_ENTITY_DEFAULT_FLAGS}
      * </ul>
      */
-    SZ_WHY_FLAGS,
+    SZ_WHY_RECORD_IN_ENTITY_FLAGS,
 
     /**
      * Flags in this usage group can be used to control the methodology for
      * performing "why analysis", what details to include for the analysis
      * and the level of detail for the entities in the network that are 
-     * returned.
+     * returned.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#whyRecords(SzRecordKey, SzRecordKey, Set)}</li>
+     * </ul>
+     * <p>
+     * The {@link SzFlag} instances included in this usage group are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_POSSIBLY_SAME_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_POSSIBLY_RELATED_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_NAME_ONLY_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_DISCLOSED_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_ALL_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_REPRESENTATIVE_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_ENTITY_NAME}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_SUMMARY}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_TYPES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_MATCHING_INFO}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_JSON_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_UNMAPPED_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_FEATURE_DETAILS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_FEATURE_STATS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_ENTITY_NAME}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_MATCHING_INFO}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_RECORD_SUMMARY}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_RECORD_TYPES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_RECORD_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_INTERNAL_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_FEATURE_STATS}
+     *      <li>{@link SzFlag#SZ_INCLUDE_MATCH_KEY_DETAILS}
+     *      <li>{@link SzFlag#SZ_INCLUDE_FEATURE_SCORES}
+     * </ul>
+     * <p>
+     * The pre-defined {@link SzFlag} {@link Set} instances that use this
+     * group and are defined for "why" operations are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_WHY_ENTITIES_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_WHY_RECORDS_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS}
+     * </ul>
+     * <p>
+     * The pre-defined {@link SzFlag} {@link Set} instances that also 
+     * support this group for defining entity or record detail levels are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_RECORD_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_ALL_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_ENTITY_BRIEF_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_VIRTUAL_ENTITY_DEFAULT_FLAGS}
+     * </ul>
+     */
+    SZ_WHY_RECORDS_FLAGS,
+
+    /**
+     * Flags in this usage group can be used to control the methodology for
+     * performing "why analysis", what details to include for the analysis
+     * and the level of detail for the entities in the network that are 
+     * returned.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#whyEntities(long, long, Set)}</li>
+     * </ul>
+     * <p>
+     * The {@link SzFlag} instances included in this usage group are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_POSSIBLY_SAME_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_POSSIBLY_RELATED_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_NAME_ONLY_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_DISCLOSED_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_ALL_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_REPRESENTATIVE_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_ENTITY_NAME}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_SUMMARY}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_TYPES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_MATCHING_INFO}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_JSON_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_UNMAPPED_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_FEATURE_DETAILS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RECORD_FEATURE_STATS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_ENTITY_NAME}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_MATCHING_INFO}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_RECORD_SUMMARY}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_RECORD_TYPES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_RELATED_RECORD_DATA}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_INTERNAL_FEATURES}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_FEATURE_STATS}
+     *      <li>{@link SzFlag#SZ_INCLUDE_MATCH_KEY_DETAILS}
+     *      <li>{@link SzFlag#SZ_INCLUDE_FEATURE_SCORES}
+     * </ul>
+     * <p>
+     * The pre-defined {@link SzFlag} {@link Set} instances that use this
+     * group and are defined for "why" operations are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_WHY_ENTITIES_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_WHY_RECORDS_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS}
+     * </ul>
+     * <p>
+     * The pre-defined {@link SzFlag} {@link Set} instances that also 
+     * support this group for defining entity or record detail levels are:
+     * <ul>
+     *      <li>{@link SzFlag#SZ_RECORD_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_ALL_RELATIONS}
+     *      <li>{@link SzFlag#SZ_ENTITY_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_ENTITY_BRIEF_DEFAULT_FLAGS}
+     *      <li>{@link SzFlag#SZ_VIRTUAL_ENTITY_DEFAULT_FLAGS}
+     * </ul>
+     */
+    SZ_WHY_ENTITIES_FLAGS,
+
+    /**
+     * Flags in this usage group can be used to control the methodology for
+     * performing "why analysis", what details to include for the analysis
+     * and the level of detail for the entities in the network that are 
+     * returned.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#whySearch(String, long, String, Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -442,11 +634,10 @@ public enum SzFlagUsageGroup {
      * Flags in this usage group can be used to control the methodology for
      * performing "how analysis", what details to include for the analysis
      * and the level of detail for the entities in the network that are 
-     * returned.
-     * Flags in this usage group can be used to control the methodology for
-     * performing "why analysis", what details to include for the analysis
-     * and the level of detail for the entities in the network that are 
-     * returned.
+     * returned.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#howEntity(long, Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -475,7 +666,10 @@ public enum SzFlagUsageGroup {
     /**
      * Flags in this usage group can be used for operations that retrieve
      * virtual entities in order to control the level of detail of the
-     * returned virtual entity.
+     * returned virtual entity.  Applicable methods include:
+     * <ul>
+     *  <li>{@link SzEngine#getVirtualEntity(Set, Set)}</li>
+     * </ul>
      * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
@@ -608,7 +802,10 @@ public enum SzFlagUsageGroup {
      * instances that can only be used for "modify" operations.
      */
     static final Set<SzFlagUsageGroup> SZ_MODIFY_SET 
-        = Collections.unmodifiableSet(EnumSet.of(SZ_MODIFY_FLAGS));
+        = Collections.unmodifiableSet(EnumSet.of(SZ_ADD_RECORD_FLAGS,
+                                                 SZ_DELETE_RECORD_FLAGS,
+                                                 SZ_REEVALUATE_FLAGS,
+                                                 SZ_REDO_FLAGS));
 
     /**
      * The package-private <b>unmodifiable</b> {@link Set} of {@link SzFlagUsageGroup}
@@ -622,7 +819,9 @@ public enum SzFlagUsageGroup {
                                                  SZ_EXPORT_FLAGS,
                                                  SZ_FIND_PATH_FLAGS,
                                                  SZ_FIND_NETWORK_FLAGS,
-                                                 SZ_WHY_FLAGS,
+                                                 SZ_WHY_RECORDS_FLAGS,
+                                                 SZ_WHY_ENTITIES_FLAGS,
+                                                 SZ_WHY_RECORD_IN_ENTITY_FLAGS,
                                                  SZ_WHY_SEARCH_FLAGS,
                                                  SZ_VIRTUAL_ENTITY_FLAGS));
 
@@ -638,7 +837,9 @@ public enum SzFlagUsageGroup {
                                                  SZ_EXPORT_FLAGS,
                                                  SZ_FIND_PATH_FLAGS,
                                                  SZ_FIND_NETWORK_FLAGS,
-                                                 SZ_WHY_FLAGS,
+                                                 SZ_WHY_RECORDS_FLAGS,
+                                                 SZ_WHY_ENTITIES_FLAGS,
+                                                 SZ_WHY_RECORD_IN_ENTITY_FLAGS,
                                                  SZ_WHY_SEARCH_FLAGS));
 
     /**
@@ -654,7 +855,9 @@ public enum SzFlagUsageGroup {
                                                  SZ_FIND_PATH_FLAGS,
                                                  SZ_FIND_NETWORK_FLAGS,
                                                  SZ_HOW_FLAGS,
-                                                 SZ_WHY_FLAGS,
+                                                 SZ_WHY_RECORDS_FLAGS,
+                                                 SZ_WHY_ENTITIES_FLAGS,
+                                                 SZ_WHY_RECORD_IN_ENTITY_FLAGS,
                                                  SZ_WHY_SEARCH_FLAGS));
 
     /**
@@ -670,7 +873,9 @@ public enum SzFlagUsageGroup {
                                                  SZ_EXPORT_FLAGS,
                                                  SZ_FIND_PATH_FLAGS,
                                                  SZ_FIND_NETWORK_FLAGS,
-                                                 SZ_WHY_FLAGS,
+                                                 SZ_WHY_RECORDS_FLAGS,
+                                                 SZ_WHY_ENTITIES_FLAGS,
+                                                 SZ_WHY_RECORD_IN_ENTITY_FLAGS,
                                                  SZ_WHY_SEARCH_FLAGS,
                                                  SZ_VIRTUAL_ENTITY_FLAGS));
 
@@ -680,8 +885,12 @@ public enum SzFlagUsageGroup {
      * "how analysis" and "why analysis" operations.
      */
     static final Set<SzFlagUsageGroup> SZ_HOW_WHY_SEARCH_SET 
-        = Collections.unmodifiableSet(EnumSet.of(
-            SZ_WHY_FLAGS, SZ_SEARCH_FLAGS, SZ_WHY_SEARCH_FLAGS, SZ_HOW_FLAGS));
+        = Collections.unmodifiableSet(EnumSet.of(SZ_WHY_RECORDS_FLAGS,
+                                                 SZ_WHY_ENTITIES_FLAGS,
+                                                 SZ_WHY_RECORD_IN_ENTITY_FLAGS,
+                                                 SZ_SEARCH_FLAGS,
+                                                 SZ_WHY_SEARCH_FLAGS,
+                                                 SZ_HOW_FLAGS));
 
     /**
      * The package-private <b>unmodifiable</b> {@link Set} of {@link SzFlagUsageGroup}

--- a/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
+++ b/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
@@ -105,7 +105,6 @@ public enum SzFlagUsageGroup {
      *  <li>{@link SzEngine#getEntity(SzRecordKey, Set)}</li>
      * </ul>
      * <p>
-     * <p>
      * The {@link SzFlag} instances included in this usage group are:
      * <ul>
      *      <li>{@link SzFlag#SZ_ENTITY_INCLUDE_POSSIBLY_SAME_RELATIONS}
@@ -436,10 +435,8 @@ public enum SzFlagUsageGroup {
      * </ul>
      * <p>
      * The pre-defined {@link SzFlag} {@link Set} instances that use this
-     * group and are defined for "why" operations are:
+     * group and are defined for "why record in entity" operations are:
      * <ul>
-     *      <li>{@link SzFlag#SZ_WHY_ENTITIES_DEFAULT_FLAGS}
-     *      <li>{@link SzFlag#SZ_WHY_RECORDS_DEFAULT_FLAGS}
      *      <li>{@link SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS}
      * </ul>
      * <p>
@@ -494,11 +491,9 @@ public enum SzFlagUsageGroup {
      * </ul>
      * <p>
      * The pre-defined {@link SzFlag} {@link Set} instances that use this
-     * group and are defined for "why" operations are:
+     * group and are defined for "why records" operations are:
      * <ul>
-     *      <li>{@link SzFlag#SZ_WHY_ENTITIES_DEFAULT_FLAGS}
      *      <li>{@link SzFlag#SZ_WHY_RECORDS_DEFAULT_FLAGS}
-     *      <li>{@link SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS}
      * </ul>
      * <p>
      * The pre-defined {@link SzFlag} {@link Set} instances that also 
@@ -552,11 +547,9 @@ public enum SzFlagUsageGroup {
      * </ul>
      * <p>
      * The pre-defined {@link SzFlag} {@link Set} instances that use this
-     * group and are defined for "why" operations are:
+     * group and are defined for "why entities" operations are:
      * <ul>
      *      <li>{@link SzFlag#SZ_WHY_ENTITIES_DEFAULT_FLAGS}
-     *      <li>{@link SzFlag#SZ_WHY_RECORDS_DEFAULT_FLAGS}
-     *      <li>{@link SzFlag#SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS}
      * </ul>
      * <p>
      * The pre-defined {@link SzFlag} {@link Set} instances that also 

--- a/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
+++ b/src/main/java/com/senzing/sdk/SzFlagUsageGroup.java
@@ -679,9 +679,9 @@ public enum SzFlagUsageGroup {
      * instances to use for {@link SzFlag} instances that can be used only for
      * "how analysis" and "why analysis" operations.
      */
-    static final Set<SzFlagUsageGroup> SZ_HOW_WHY_SET 
+    static final Set<SzFlagUsageGroup> SZ_HOW_WHY_SEARCH_SET 
         = Collections.unmodifiableSet(EnumSet.of(
-            SZ_WHY_FLAGS, SZ_WHY_SEARCH_FLAGS, SZ_HOW_FLAGS));
+            SZ_WHY_FLAGS, SZ_SEARCH_FLAGS, SZ_WHY_SEARCH_FLAGS, SZ_HOW_FLAGS));
 
     /**
      * The package-private <b>unmodifiable</b> {@link Set} of {@link SzFlagUsageGroup}
@@ -805,7 +805,7 @@ public enum SzFlagUsageGroup {
         map.put(SzFlagHelpers.SZ_RELATION_SET, SzFlagUsageGroup.SZ_RELATION_SET);
         map.put(SzFlagHelpers.SZ_ENTITY_RECORD_SET, SzFlagUsageGroup.SZ_ENTITY_RECORD_SET);
         map.put(SzFlagHelpers.SZ_ENTITY_HOW_SET, SzFlagUsageGroup.SZ_ENTITY_HOW_SET);
-        map.put(SzFlagHelpers.SZ_HOW_WHY_SET, SzFlagUsageGroup.SZ_HOW_WHY_SET);
+        map.put(SzFlagHelpers.SZ_HOW_WHY_SEARCH_SET, SzFlagUsageGroup.SZ_HOW_WHY_SEARCH_SET);
         map.put(SzFlagHelpers.SZ_SEARCH_SET, SzFlagUsageGroup.SZ_SEARCH_SET);
         map.put(SzFlagHelpers.SZ_WHY_SEARCH_SET, SzFlagUsageGroup.SZ_WHY_SEARCH_SET);
         map.put(SzFlagHelpers.SZ_EXPORT_SET, SzFlagUsageGroup.SZ_EXPORT_SET);

--- a/src/test/java/com/senzing/sdk/core/SzCoreEngineWhyTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreEngineWhyTest.java
@@ -16,10 +16,8 @@ import java.util.Map;
 import java.util.TreeSet;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -142,7 +140,7 @@ public class SzCoreEngineWhyTest extends AbstractTest {
         list.add(null);
         list.add(SZ_NO_FLAGS);
         list.add(SZ_WHY_ENTITIES_DEFAULT_FLAGS);
-        list.add(SZ_WHY_ALL_FLAGS);
+        list.add(SZ_WHY_ENTITIES_ALL_FLAGS);
         list.add(Collections.unmodifiableSet(EnumSet.of(
                 SZ_ENTITY_INCLUDE_ENTITY_NAME,
                 SZ_ENTITY_INCLUDE_RECORD_SUMMARY,
@@ -158,7 +156,7 @@ public class SzCoreEngineWhyTest extends AbstractTest {
         list.add(null);
         list.add(SZ_NO_FLAGS);
         list.add(SZ_WHY_SEARCH_DEFAULT_FLAGS);
-        list.add(SZ_WHY_ALL_FLAGS);
+        list.add(SZ_WHY_SEARCH_ALL_FLAGS);
         list.add(Collections.unmodifiableSet(EnumSet.of(
                 SZ_SEARCH_INCLUDE_REQUEST,
                 SZ_SEARCH_INCLUDE_REQUEST_DETAILS,
@@ -189,7 +187,7 @@ public class SzCoreEngineWhyTest extends AbstractTest {
         list.add(null);
         list.add(SZ_NO_FLAGS);
         list.add(SZ_WHY_RECORDS_DEFAULT_FLAGS);
-        list.add(SZ_WHY_ALL_FLAGS);
+        list.add(SZ_WHY_RECORDS_ALL_FLAGS);
         list.add(Collections.unmodifiableSet(EnumSet.of(
                 SZ_ENTITY_INCLUDE_ENTITY_NAME,
                 SZ_ENTITY_INCLUDE_RECORD_SUMMARY,
@@ -205,7 +203,7 @@ public class SzCoreEngineWhyTest extends AbstractTest {
         list.add(null);
         list.add(SZ_NO_FLAGS);
         list.add(SZ_WHY_RECORD_IN_ENTITY_DEFAULT_FLAGS);
-        list.add(SZ_WHY_ALL_FLAGS);
+        list.add(SZ_WHY_RECORD_IN_ENTITY_ALL_FLAGS);
         list.add(Collections.unmodifiableSet(EnumSet.of(
                 SZ_ENTITY_INCLUDE_ENTITY_NAME,
                 SZ_ENTITY_INCLUDE_RECORD_SUMMARY,

--- a/src/test/java/com/senzing/sdk/core/SzFlagUsageGroupTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzFlagUsageGroupTest.java
@@ -2,6 +2,7 @@ package com.senzing.sdk.core;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.Map;
 import java.util.EnumSet;
@@ -10,7 +11,9 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Collections;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,16 +25,28 @@ import com.senzing.sdk.SzFlagUsageGroup;
 
 import static org.junit.jupiter.api.TestInstance.Lifecycle;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static com.senzing.sdk.core.AbstractTest.*;
 import static com.senzing.sdk.core.Utilities.hexFormat;
+import static com.senzing.sdk.core.SzFlagsMetaData.SzFlagMetaData;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @Execution(ExecutionMode.SAME_THREAD)
 public class SzFlagUsageGroupTest {
 
+    /**
+     * The {@link SzFlagsMetaData} describing all the flags.
+     */
+    private SzFlagsMetaData flagsMetaData = null;
+
     private List<SzFlagUsageGroup> getEnumFlagGroups() {
         return Arrays.asList(SzFlagUsageGroup.values());
+    }
+
+    private List<String> getMetaFlagGroups() {
+        return new ArrayList<>(this.flagsMetaData.getGroups());
     }
 
     private List<Arguments> getToStringParameters() {
@@ -80,7 +95,36 @@ public class SzFlagUsageGroupTest {
             }
         }
         return result;
-    }   
+    }
+
+    @BeforeAll
+    public void reflectFlags() {
+        try {
+            this.flagsMetaData = new SzFlagsMetaData();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMetaFlagGroups")
+    void testMetaGroupFound(String groupName) {
+        try {
+            SzFlagUsageGroup group = SzFlagUsageGroup.valueOf(groupName);
+            assertNotNull(group, "Group for name was null: " + groupName);
+        } catch (Exception e) {
+            fail("Could not get group for name: " + groupName, e);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEnumFlagGroups")
+    void testGroupFoundInMeta(SzFlagUsageGroup group) {
+        String groupName = group.name();
+        assertTrue(this.flagsMetaData.getGroups().contains(groupName),
+                   "Group (" + groupName + ") not found in groups meta data: "
+                   + this.flagsMetaData.getGroups());
+    }
 
     @ParameterizedTest
     @MethodSource("getEnumFlagGroups")
@@ -134,8 +178,28 @@ public class SzFlagUsageGroupTest {
     @ParameterizedTest
     @MethodSource("getEnumFlagGroups")
     void testGetFlags(SzFlagUsageGroup group) {
+        Map<String, SzFlagMetaData> flagsMap 
+            = this.flagsMetaData.getBaseFlagsByGroup(group.name());
+
         Set<SzFlag> flags = group.getFlags();
         assertNotNull(flags, "Flags for group should not be null: " + group);
+
+        Set<String> flagNames = new LinkedHashSet<>();
+        for (SzFlag flag : flags) {
+            flagNames.add(flag.name());
+        }
+        
+        for (String flagName : flagsMap.keySet()) {
+            assertTrue(flagNames.contains(flagName),
+                       "Flag (" + flagName + ") found in meta data, "
+                       + "missing from flag usage group: " + group);
+        }
+        for (String flagName : flagNames) {
+            assertTrue(flagsMap.containsKey(flagName), 
+                       "Unexpeted flag (" + flagName + ") found in group, "
+                       + "missing from meta: " + group);
+        }
+
         for (SzFlag flag: flags) {
             Set<SzFlagUsageGroup> groups = flag.getGroups();
             assertNotNull(groups, "Groups for flag should not be null: " + flag);

--- a/src/test/java/com/senzing/sdk/core/SzFlagUsageGroupTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzFlagUsageGroupTest.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
@@ -26,10 +25,9 @@ import com.senzing.sdk.SzFlagUsageGroup;
 import static org.junit.jupiter.api.TestInstance.Lifecycle;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static com.senzing.sdk.core.AbstractTest.*;
 import static com.senzing.sdk.core.Utilities.hexFormat;
+import static com.senzing.sdk.SzFlagUsageGroup.SZ_HOW_FLAGS;
 import static com.senzing.sdk.core.SzFlagsMetaData.SzFlagMetaData;
 
 @TestInstance(Lifecycle.PER_CLASS)

--- a/src/test/java/com/senzing/sdk/core/SzFlagsMetaData.java
+++ b/src/test/java/com/senzing/sdk/core/SzFlagsMetaData.java
@@ -1,0 +1,374 @@
+package com.senzing.sdk.core;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.LinkedHashSet;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+
+import com.senzing.io.IOUtilities;
+import com.senzing.nativeapi.InstallLocations;
+import com.senzing.util.JsonUtilities;
+
+import javax.json.JsonArray;
+
+import static com.senzing.io.IOUtilities.UTF_8;
+import static com.senzing.util.JsonUtilities.*;
+
+/**
+ * Loads the flags JSON meta data file and makes its properties available.
+ */
+public class SzFlagsMetaData {
+    private static final String SYMBOL_KEY = "symbol";
+    private static final String BITS_KEY = "bits";
+    private static final String VALUE_KEY = "value";
+    private static final String DEFINITION_KEY = "definition";
+    private static final String GROUPS_KEY = "groups";
+    private static final String FLAGS_KEY = "flags";
+    
+    /**
+     * Provides the meta data describing a specific flag.
+     */
+    public static class SzFlagMetaData {
+        private final String symbol;
+        private final Set<Integer> bits;
+        private final long value;
+        private final Set<String> definition;
+        private final Set<String> groups;
+        private final Set<String> flags;
+
+        private SzFlagMetaData(JsonObject jsonObject) {
+            // get the symbol
+            this.symbol = getString(jsonObject, SYMBOL_KEY);
+
+            // get the bits
+            JsonArray bitsArray = getJsonArray(jsonObject, BITS_KEY);
+            Set<Integer> bitSet = new LinkedHashSet<>();
+            for (int index = 0; index < bitsArray.size(); index++) {
+                bitSet.add(getInteger(bitsArray, index));
+            }
+            this.bits = Collections.unmodifiableSet(bitSet);
+
+            // get the value
+            this.value = getLong(jsonObject, VALUE_KEY);
+
+            // get the definition
+            JsonValue defValue = getJsonValue(jsonObject, DEFINITION_KEY);
+            Set<String> defSet = new LinkedHashSet<>();
+            if (defValue instanceof JsonArray) {
+                defSet.addAll(getStrings(jsonObject, DEFINITION_KEY));
+            } else {
+                defSet.add(getString(jsonObject, DEFINITION_KEY));
+            }
+            this.definition = Collections.unmodifiableSet(defSet);
+
+            // get the groups
+            this.groups = Collections.unmodifiableSet(
+                new LinkedHashSet<>(getStrings(jsonObject, GROUPS_KEY)));
+
+            // get the sub-flags (if any)
+            List<String> subflags = getStrings(jsonObject, FLAGS_KEY);
+            this.flags = (subflags == null) 
+                ? null 
+                : Collections.unmodifiableSet(new LinkedHashSet<>(subflags));
+        }
+
+        /**
+         * Gets the symbol for this flag.
+         * 
+         * @return The sumbol for this flag.
+         */
+        public String getSymbol() {
+            return this.symbol;
+        }
+
+        /**
+         * Gets the 64-bit <code>long</code> value for this flag.
+         * 
+         * @return The 64-bit <code>long</code> value for this flag.
+         */
+        public long getValue() {
+            return this.value;
+        }
+
+        /**
+         * Gets the <b>unmodifiable</b> {@link Set} of {@link Integer} 
+         * bit indices that are active for this flag.
+         * 
+         * @return The <b>unmodifiable</b> {@link Set} of {@link Integer} 
+         *         bit indices that are active for this flag.
+         */
+        public Set<Integer> getBits() {
+            return this.bits;
+        }
+
+        /**
+         * Gets the <b>unmodifiable</b> {@link Set} of {@link String}
+         * definitions for this flag.  If this flag is defined in terms
+         * of its actual value, then there is a single member of the form
+         * <code>"1 << N"</code> where <code>N</code> is the bit index
+         * that is set.  If this flag is defined in terms of one or more
+         * other flags then the members of the {@link Set} are the names
+         * of this flags that are used to define this flag through
+         * bitwise-OR operations.
+         * 
+         * @return The <b>unmodifiable</b> {@link Set} of {@link String} 
+         *         definitions for this flag.
+         */
+        public Set<String> getDefinition() {
+            return this.definition;
+        }
+
+        /**
+         * Gets the <b>unmodifiable</b> {@link Set} of {@link String} base flag
+         * names that identify the single-bit base flags aggregated by this flag,
+         * or <code>null</code> if this flag is itself a base flag.
+         * <p>
+         * <b>NOTE:</b> A flag may still be a base flag even if it is defined 
+         * in terms of another flag because some flags have the same underlying
+         * value.  Several of the "search" related flags are examples of this as
+         * they are defined in terms of the "export" flags that perform a similar
+         * funtion.
+         * 
+         * @return The <b>unmodifiable</b> {@link Set} of {@link String} base flag
+         *         names that identify the single-bit base flags aggregated by this
+         *         flag, or <code>null</code> if this flag is itself a base flag.
+         */
+        public Set<String> getBaseFlags() {
+            return this.flags;
+        }
+
+        /**
+         * Gets the <b>unmodifiable</b> {@link Set} of flag usage group names
+         * identifying the usage groups to which this flag is applicable.
+         * 
+         * @return The <b>unmodifiable</b> {@link Set} of flag usage group
+         *         names identifying the usage groups to which this flag is
+         *         applicable.
+         */
+        public Set<String> getGroups() {
+            return this.groups;
+        }
+    }
+
+    private Set<String> groups;
+
+    private Map<String, SzFlagMetaData> flagsByName;
+
+    private Map<String, Map<String, SzFlagMetaData>> flagsByGroup;
+
+    private Map<String, SzFlagMetaData> baseFlagsByName;
+
+    private Map<String, Map<String, SzFlagMetaData>> baseFlagsByGroup;
+
+    private Map<String, SzFlagMetaData> aggrFlagsByName;
+
+    private Map<String, Map<String, SzFlagMetaData>> aggrFlagsByGroup;
+
+    private static File getFlagsMetaDataFile() throws IOException {
+        InstallLocations locations = InstallLocations.findLocations();
+        File baseDir = locations.getInstallDirectory();
+        File sdkDir = new File(baseDir, "sdk");
+        return new File(sdkDir, "szflags.json");
+    }
+
+    public SzFlagsMetaData() throws IOException {
+        this(getFlagsMetaDataFile());
+    }
+
+    public SzFlagsMetaData(File flagsFile) throws IOException
+    {
+        Map<String, SzFlagMetaData> flagsMap = new LinkedHashMap<>();
+        String jsonText = IOUtilities.readTextFileAsString(flagsFile, UTF_8);
+        JsonArray jsonArray = JsonUtilities.parseJsonArray(jsonText);
+        for (JsonObject jsonObject : jsonArray.getValuesAs(JsonObject.class)) {
+            SzFlagMetaData info = new SzFlagMetaData(jsonObject);
+            flagsMap.put(info.symbol, info);
+        }
+        this.flagsByName = Collections.unmodifiableMap(flagsMap);
+
+        Set<String> groupSet = new TreeSet<>();
+        Map<String, SzFlagMetaData> baseMap = new LinkedHashMap<>();
+        Map<String, SzFlagMetaData> aggrMap = new LinkedHashMap<>();
+        Map<String, Map<String, SzFlagMetaData>> groupMap = new LinkedHashMap<>();
+        Map<String, Map<String, SzFlagMetaData>> baseGroupMap = new LinkedHashMap<>();
+        Map<String, Map<String, SzFlagMetaData>> aggrGroupMap = new LinkedHashMap<>();
+        
+        for (SzFlagMetaData fmd : this.flagsByName.values()) {
+            if (fmd.getBaseFlags() == null) {
+                baseMap.put(fmd.getSymbol(), fmd);
+            } else {
+                aggrMap.put(fmd.getSymbol(), fmd);
+            }
+
+            // get the groups
+            for (String group : fmd.getGroups()) {
+                groupSet.add(group);
+                Map<String, SzFlagMetaData> groupFlags = groupMap.get(group);
+                if (groupFlags == null) {
+                    groupFlags = new LinkedHashMap<>();
+                    groupMap.put(group, groupFlags);
+                }
+                groupFlags.put(fmd.getSymbol(), fmd);
+                
+                Map<String, Map<String, SzFlagMetaData>> parentMap = null;
+                if (fmd.getBaseFlags() == null) {
+                    parentMap = baseGroupMap;
+                } else {
+                    parentMap = aggrGroupMap;
+                }
+
+                groupFlags = parentMap.get(group);
+                if (groupFlags == null) {
+                    groupFlags = new LinkedHashMap<>();
+                    parentMap.put(group, groupFlags);
+                }
+                groupFlags.put(fmd.getSymbol(), fmd);           
+            }
+        }
+
+        //  make all sub-maps unmodifiable
+        List<Map<String, Map<String, SzFlagMetaData>>> parentMaps
+            = List.of(groupMap, baseGroupMap, aggrGroupMap);
+        
+        for (Map<String, Map<String, SzFlagMetaData>> parent : parentMaps) {
+            for (Map.Entry<String, Map<String, SzFlagMetaData>> entry : parent.entrySet())
+            {
+                Map<String, SzFlagMetaData> map = entry.getValue();
+                map = Collections.unmodifiableMap(map);
+                entry.setValue(map);
+            }
+        }
+
+        this.groups             = Collections.unmodifiableSet(new LinkedHashSet<>(groupSet));
+        this.baseFlagsByName    = Collections.unmodifiableMap(baseMap);
+        this.aggrFlagsByName    = Collections.unmodifiableMap(aggrMap);
+        this.flagsByGroup       = Collections.unmodifiableMap(groupMap);
+        this.baseFlagsByGroup   = Collections.unmodifiableMap(baseGroupMap);
+        this.aggrFlagsByGroup   = Collections.unmodifiableMap(aggrGroupMap);
+    }
+
+    /**
+     * Gets an <b>unmodifiable</b> {@link Map} of {@link String} flag name
+     * keys to {@link SzFlagMetaData} values for all flags.
+     * 
+     * @return An <b>unmodifiable</b> {@link Map} of {@link String} flag
+     *         name keys to {@link SzFlagMetaData} values for all flags.
+     */
+    public Map<String, SzFlagMetaData> getFlags() {
+        return this.flagsByName;
+    }
+
+    /**
+     * Gets the {@link SzFlagMetaData} for the flag with the specified 
+     * name.  This returns <code>null</code> if the specified name is not
+     * recognized.
+     * 
+     * @returns The {@link SzFlagMetaData} for the flag with the specified
+     *          name, or <code>null</code> if the specified name is not 
+     *          recognized.
+     */
+    public SzFlagMetaData getFlag(String name) {
+        return this.flagsByName.get(name);
+    }
+
+    /**
+     * Gets an <b>unmodifiable</b> {@link Set} of {@link String} group names
+     * for all groups that are found for the flags.
+     * 
+     * @return An <b>unmodifiable</b> {@link Set} of {@link String} group
+     *         names for all groups that are found for the flags.
+     */
+    public Set<String> getGroups() {
+        return this.groups;
+    }
+
+    /**
+     * Gets an <b>unmodifiable</b> {@link Map} of {@link String} flag name
+     * keys to {@link SzFlagMetaData} values for all flags belonging to 
+     * the group identified by the specified name.  If the specified group
+     * name is not recognized then <code>null</code> is returned.
+     * 
+     * @param group The group name identifying the group.
+     * 
+     * @return An <b>unmodifiable</b> {@link Map} of {@link String} flag
+     *         name keys to {@link SzFlagMetaData} values for all flags
+     *         belonging to the group identified by the specified name,
+     *         or <code>null</code> if the specified group name is not 
+     *         recognized.
+     */
+    public Map<String, SzFlagMetaData> getFlagsByGroup(String group) {
+        return this.flagsByGroup.get(group);
+    }
+
+    /**
+     * Gets an <b>unmodifiable</b> {@link Map} of {@link String} flag name
+     * keys to {@link SzFlagMetaData} values for all base flags (i.e.: those
+     * flags that do <b>not</b> have composite base flags).
+     * 
+     * @return An <b>unmodifiable</b> {@link Map} of {@link String} flag
+     *         name keys to {@link SzFlagMetaData} values for all base flags.
+     */
+    public Map<String, SzFlagMetaData> getBaseFlags() {
+        return this.baseFlagsByName;
+    }
+
+    /**
+     * Gets an <b>unmodifiable</b> {@link Map} of {@link String} flag name
+     * keys to {@link SzFlagMetaData} values for all aggregate flags (i.e.:
+     * those flags that do have composite base flags).
+     * 
+     * @return An <b>unmodifiable</b> {@link Map} of {@link String} flag
+     *         name keys to {@link SzFlagMetaData} values for all aggregate
+     *         flags.
+     */
+    public Map<String, SzFlagMetaData> getAggregateFlags() {
+        return this.aggrFlagsByName;
+    }
+
+    /**
+     * Gets an <b>unmodifiable</b> {@link Map} of {@link String} flag name
+     * keys to {@link SzFlagMetaData} values for all base flags belonging
+     * to the group identified by the specified name.  Base flags are those
+     * that do <b>not</b> have composite base flags.  If the specified group
+     * name is not recognized then <code>null</code> is returned.
+     * 
+     * @param group The group name identifying the group.
+     * 
+     * @return An <b>unmodifiable</b> {@link Map} of {@link String} flag
+     *         name keys to {@link SzFlagMetaData} values for all base 
+     *         flags belonging to the group identified by the specified
+     *         name, or <code>null</code> if the specified group name is
+     *         not recognized.
+     */
+    public Map<String, SzFlagMetaData> getBaseFlagsByGroup(String group) {
+        return this.baseFlagsByGroup.get(group);
+    }
+
+    /**
+     * Gets an <b>unmodifiable</b> {@link Map} of {@link String} flag name
+     * keys to {@link SzFlagMetaData} values for all aggregate flags
+     * belonging to the group identified by the specified name.  Aggregate
+     * flags are those that do have composite base flags.  If the specified
+     * group name is not recognized then <code>null</code> is returned.
+     * 
+     * @param group The group name identifying the group.
+     * 
+     * @return An <b>unmodifiable</b> {@link Map} of {@link String} flag
+     *         name keys to {@link SzFlagMetaData} values for all aggregate
+     *         flags belonging to the group identified by the specified
+     *         name, or <code>null</code> if the specified group name is
+     *         not recognized.
+     */
+    public Map<String, SzFlagMetaData> getAggregateFlagsByGroup(String group) {
+        return this.aggrFlagsByGroup.get(group);
+    }
+}

--- a/src/test/java/com/senzing/sdk/core/SzFlagsMetaData.java
+++ b/src/test/java/com/senzing/sdk/core/SzFlagsMetaData.java
@@ -117,7 +117,7 @@ public class SzFlagsMetaData {
          * <code>"1 << N"</code> where <code>N</code> is the bit index
          * that is set.  If this flag is defined in terms of one or more
          * other flags then the members of the {@link Set} are the names
-         * of this flags that are used to define this flag through
+         * of those flags that are used to define this flag through
          * bitwise-OR operations.
          * 
          * @return The <b>unmodifiable</b> {@link Set} of {@link String} 
@@ -136,7 +136,7 @@ public class SzFlagsMetaData {
          * in terms of another flag because some flags have the same underlying
          * value.  Several of the "search" related flags are examples of this as
          * they are defined in terms of the "export" flags that perform a similar
-         * funtion.
+         * function.
          * 
          * @return The <b>unmodifiable</b> {@link Set} of {@link String} base flag
          *         names that identify the single-bit base flags aggregated by this

--- a/src/test/java/com/senzing/sdk/core/SzFlagsTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzFlagsTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -12,14 +13,17 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import com.senzing.sdk.SzFlags;
+import com.senzing.sdk.core.SzFlagsMetaData.SzFlagMetaData;
 
 import static org.junit.jupiter.api.TestInstance.Lifecycle;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import static com.senzing.sdk.core.Utilities.*;
+import static com.senzing.sdk.core.SzFlagsMetaData.SzFlagMetaData;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @Execution(ExecutionMode.SAME_THREAD)
@@ -36,9 +40,19 @@ public class SzFlagsTest extends AbstractTest {
      */
     private Map<String, Long> sdkFlagMap = new LinkedHashMap<>();
 
+    /**
+     * The {@link SzFlagsMetaData} describing all the flags.
+     */
+    private SzFlagsMetaData flagsMetaData = null;
 
     @BeforeAll
     public void reflectFlags() {
+        try {
+            this.flagsMetaData = new SzFlagsMetaData();
+        } catch (Exception e) {
+            fail(e);
+        }
+
         Field[] fields = NativeEngine.class.getDeclaredFields();
         for (Field field : fields) {
             int modifiers = field.getModifiers();
@@ -88,18 +102,62 @@ public class SzFlagsTest extends AbstractTest {
         return results;
     }
 
+    private List<Arguments> getMetaMappings() {
+        Map<String, SzFlagMetaData> metaMap = this.flagsMetaData.getFlags();
+
+        List<Arguments> results = new ArrayList<>(metaMap.size());
+        metaMap.values().forEach((metaData) -> {
+            results.add(Arguments.of(metaData.getSymbol(), metaData.getValue()));
+        });
+        return results;
+    }
+
     @ParameterizedTest
     @MethodSource("getNativeMappings")
     public void testNativeFlag(String flagName, long value) {
-        String sdkFlagName = "SZ" + flagName.substring(2);
-        assertTrue(this.sdkFlagMap.containsKey(sdkFlagName),
-            "SDK flag constant (" + sdkFlagName +") not found for "
+        assertTrue(this.sdkFlagMap.containsKey(flagName),
+            "SDK flag constant (" + flagName +") not found for "
             + "native flag constant (" + flagName + ")");
-        Long sdkValue = this.sdkFlagMap.get(sdkFlagName);
+        Long sdkValue = this.sdkFlagMap.get(flagName);
         assertEquals(value, sdkValue, 
-            "SDK flag constant (" + sdkFlagName +") has different value ("
+            "SDK flag constant (" + flagName +") has different value ("
             + hexFormat(sdkValue) + ") than native flag constant (" 
             + flagName + "): " + hexFormat(value));
+        SzFlagMetaData metaData = this.flagsMetaData.getFlag(flagName);
+        assertNotNull(metaData, "Native flag constant (" + flagName 
+                      + ") not found in meta data");
+        assertEquals(metaData.getValue(), value,
+           "Native flag constant (" + flagName +") has different value ("
+            + hexFormat(value) + ") than value found in meta-data: "
+            + hexFormat(metaData.getValue()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMetaMappings")
+    public void testMetaFlag(String flagName, long value) {
+        assertTrue(this.sdkFlagMap.containsKey(flagName),
+            "SDK flag constant (" + flagName +") not found for "
+            + "meta flag constant (" + flagName + ")");
+        Long sdkValue = this.sdkFlagMap.get(flagName);
+        assertEquals(value, sdkValue, 
+            "SDK flag constant (" + flagName +") has different value ("
+            + hexFormat(sdkValue) + ") than meta flag constant (" 
+            + flagName + "): " + hexFormat(value));
+
+        if (!flagName.equals("SZ_WITH_INFO")) {
+            assertTrue(this.nativeFlagMap.containsKey(flagName),
+                "Meta flag constant (" + flagName +") not found for "
+                + "native flag constant (" + flagName + ")");
+            Long nativeValue = this.nativeFlagMap.get(flagName);
+            assertEquals(value, nativeValue, 
+                "Native flag constant (" + flagName +") has different value ("
+                + hexFormat(nativeValue) + ") than meta flag constant (" 
+                + flagName + "): " + hexFormat(value));
+        } else {
+            assertFalse(this.nativeFlagMap.containsKey(flagName),
+                "Meta flag constant (" + flagName + ") unexpectedly found for "
+                + "in the nativd flag constants.");
+        }
     }
 
     @ParameterizedTest
@@ -107,12 +165,26 @@ public class SzFlagsTest extends AbstractTest {
     public void testSdkFlag(String flagName, long value) {
         String nativeFlagName = flagName;
 
+        if (!flagName.equals("SZ_NO_FLAGS")
+            && !flagName.equals("SZ_WITH_INFO_FLAGS"))
+        {
+            SzFlagMetaData metaData = this.flagsMetaData.getFlag(flagName);
+            assertNotNull(metaData, "SzFlags flag constant (" + flagName 
+                        + ") not found in meta data");
+
+            assertEquals(metaData.getValue(), value,
+            "SzFlags flag constant (" + flagName +") has different value ("
+                + hexFormat(value) + ") than value found in meta-data: "
+                + hexFormat(metaData.getValue()));
+        }
+
         if (nativeFlagName.equals("SZ_WITH_INFO") 
             || nativeFlagName.equals("SZ_NO_FLAGS")
             || nativeFlagName.equals("SZ_WITH_INFO_FLAGS"))
         {
             assertFalse(this.nativeFlagMap.containsKey(nativeFlagName),
                 "Native flags unexpectedly includes " + nativeFlagName);
+        
         } else {
             assertTrue(this.nativeFlagMap.containsKey(nativeFlagName),
                 "Native flag constant (" + nativeFlagName +") not found for "


### PR DESCRIPTION
Updates to flag groups to make them more granular (in light of "why search" functionality).

Added flag tests based on meta data and made minor corrections.

Resolves Issue #147