### PR TITLE
#166: Renamed `getConfigs()` to `getConfigRegistry()` in `SzConfigManager` (including implementations and examples)

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -92,7 +92,6 @@
     "ignorePaths": [
       ".git/**",
       "**/test/**",
-      "CHANGELOG.md",
       "Makefile",
       "pom.xml"
     ]

--- a/src/demo/java/com/senzing/sdk/SzConfigManagerDemo.java
+++ b/src/demo/java/com/senzing/sdk/SzConfigManagerDemo.java
@@ -240,9 +240,9 @@ public class SzConfigManagerDemo extends AbstractTest {
     }
 
     @Test
-    public void getConfigsDemo() {
+    public void getConfigRegistryDemo() {
         try {
-            // @start region="getConfigs"
+            // @start region="getConfigRegistry"
             // How to get a JSON document describing all registered configs
             try {
                 // obtain the SzEnvironment (varies by application)
@@ -277,7 +277,7 @@ public class SzConfigManagerDemo extends AbstractTest {
                 // handle or rethrow the exception
                 logError("Failed to get configurations.", e); // @highlight type="italic"
             }
-            // @end region="getConfigs"
+            // @end region="getConfigRegistry"
 
         } catch (Exception e) {
             fail(e);

--- a/src/demo/java/com/senzing/sdk/SzConfigManagerDemo.java
+++ b/src/demo/java/com/senzing/sdk/SzConfigManagerDemo.java
@@ -254,12 +254,12 @@ public class SzConfigManagerDemo extends AbstractTest {
                 SzConfigManager configMgr = env.getConfigManager();
 
                 // get the config definition for the config ID
-                String configsJson = configMgr.getConfigs(); // @highlight regex="String.*"
+                String configRegistry = configMgr.getConfigRegistry(); // @highlight regex="String.*"
 
                 // do something with the returned JSON (e.g.: parse it and extract values)
                 // @highlight type="italic" region="doSomething"
                 JsonObject jsonObj = Json.createReader(
-                    new StringReader(configsJson)).readObject();       // @highlight regex="configsJson"
+                    new StringReader(configRegistry)).readObject();    // @highlight regex="configsJson"
                 
                 JsonArray jsonArr = jsonObj.getJsonArray("CONFIGS");   // @highlight regex=".CONFIGS."
 

--- a/src/main/java/com/senzing/sdk/SzConfigManager.java
+++ b/src/main/java/com/senzing/sdk/SzConfigManager.java
@@ -165,7 +165,7 @@ public interface SzConfigManager {
      * </pre>
      *
      * <p><b>Usage:</b>
-     * {@snippet class="com.senzing.sdk.SzConfigManagerDemo" region="getConfigs"}
+     * {@snippet class="com.senzing.sdk.SzConfigManagerDemo" region="getConfigRegistry"}
      * </p>
      *
      * @return The JSON {@link String} describing the configurations registered

--- a/src/main/java/com/senzing/sdk/SzConfigManager.java
+++ b/src/main/java/com/senzing/sdk/SzConfigManager.java
@@ -174,7 +174,7 @@ public interface SzConfigManager {
      * 
      * @throws SzException If a failure occurs.
      */
-    String getConfigs() throws SzException;
+    String getConfigRegistry() throws SzException;
 
     /**
      * Gets the configuration ID of the default configuration for the repository

--- a/src/main/java/com/senzing/sdk/core/SzCoreConfigManager.java
+++ b/src/main/java/com/senzing/sdk/core/SzCoreConfigManager.java
@@ -426,7 +426,7 @@ class SzCoreConfigManager implements SzConfigManager {
      * Implemented to call the underlying native function.
      */
     @Override
-    public String getConfigs() throws SzException {
+    public String getConfigRegistry() throws SzException {
         return this.env.execute(() -> {
             // get the config manager API
             NativeConfigManager nativeApi = this.getConfigManagerApi();

--- a/src/test/java/com/senzing/sdk/core/SzCoreConfigManagerTest.java
+++ b/src/test/java/com/senzing/sdk/core/SzCoreConfigManagerTest.java
@@ -377,7 +377,7 @@ public class SzCoreConfigManagerTest extends AbstractTest {
             try {
                 SzConfigManager configMgr = this.env.getConfigManager();
                     
-                String result = configMgr.getConfigs();
+                String result = configMgr.getConfigRegistry();
                 
                 JsonObject jsonObj = parseJsonObject(result);
 


### PR DESCRIPTION
Resolves Issue #166 

- Modified `SzConfigManager.java` interface to rename `getConfigs()` to `getConfigRegistry()`
- Modified `SzCoreConfigManager.java` class to rename `getConfigs()` to `getConfigRegistry()`
- Modified `SzCoreConfigManagerTest.java` to rename `getConfigs()` to `getConfigRegistry()`
- Modified `SzConfigManagerDemo.java` to rename `getConfigs()` to `getConfigRegistry()`
