### PR TITLE
Updated create-javadoc-documentation.yaml workflow to account for example file generation

### DIFF
--- a/.github/workflows/create-javadoc-documentation.yaml
+++ b/.github/workflows/create-javadoc-documentation.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          mvn -Dtest=\*Demo test javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -87,7 +87,8 @@
       "USERPROFILE",
       "UTYPE",
       "WATCHLIST",
-      "XLITERATOR"
+      "XLITERATOR",
+      "Dtest"
     ],
     "ignorePaths": [
       ".git/**",


### PR DESCRIPTION
Resolves Issue #190 for GitHub action docs generation